### PR TITLE
Tighten up route selection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ internals.docs = function (settings) {
             // remove unneeded routes - uses startWith path match
             routes = routes.filter(function (item) {
                 if (request.query.path &&
-                    item.path.indexOf('/' + request.query.path) !== 0 ) {
+                    item.path.search('^/' + request.query.path + '(/|$)') !== 0 ) {
                     return false;
                 }
                 return item.settings.plugins['hapi-swagger'] !== false && item.method !== 'options';


### PR DESCRIPTION
Recent change has ensured previously hidden routes are now visible but
now matches too broadly e.g. indexOf looking for ‘/movies’ would also
match ‘/moviescenes’ when it shouldn’t.

Using ‘search’ with a regular expression ensures we get only the routes
we want.

A jsFiddle illustrates the difference: http://jsfiddle.net/davidwaterston/cC4v8/
