### PR TITLE
Changes for latest versions of Joi

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,8 +43,8 @@ internals.docs = function (settings) {
         auth: settings.auth,
         validate: {
             query: {
-                path: Joi.types.String(),
-                api_key: Joi.types.String()
+                path: Joi.string(),
+                api_key: Joi.string()
             }
         },
         handler: function (request, reply) {


### PR DESCRIPTION
Hi

I noticed that hapi-swagger may not be up to date with the latest versions of Joi, as described here https://github.com/spumko/joi#migration-notes so here's a small fix.

Otherwise you can get a error when passing any of these params in the URL
