### PR TITLE
Added configurable path prefix size

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ var internals = {
     defaults: {
         endpoint: '/docs',
         auth: false,
-        basePath: ''
+        basePath: '',
+        pathPrefixSize: 1,
     }
 };
 
@@ -139,6 +140,7 @@ internals.buildAPIDiscovery = function( settings, routes ){
     var i = routes.length,
         x = 0,
         parts,
+        prefix,
         apis = [],
         swagger = {
             "apiVersion": "unknown",
@@ -156,22 +158,42 @@ internals.buildAPIDiscovery = function( settings, routes ){
         var route = routes[x]
         if(route.settings.tags && route.settings.tags.indexOf('api') > -1){
             parts = route.path.split('/');
-
+            prefix = internals._commonPrefix(settings, route.path);
             // only add a group once base on the starting path segment
-            if(apis.indexOf(parts[1]) === -1){
+            if(apis.indexOf(prefix) === -1){
                 swagger.apis.push({
-                    "path": '/docs?path=' + parts[1],
+                    "path": settings.endpoint + '?path=' + prefix,
                     "description": route.settings.description
                 })
-                apis.push(parts[1]);
+                apis.push(prefix);
             }
         }
         x++;
     }
 
     return swagger;
-}
+};
 
+internals._commonPrefix = function( settings, path ){
+    var i = 0,
+    path_head = [],
+    prefix,
+    parts;
+    parts = path.split('/');
+    while (parts.length > 0) {
+        var item = parts.shift();
+        if (item !== '') {
+            path_head.push(item);
+            // only count when it's a path element (and not the initial /)
+            i++;
+        }
+        if (i >= settings.pathPrefixSize) {
+            break;
+        }
+    }
+    prefix = path_head.join('/');
+    return prefix;
+}
 
 // build documentation API endpoint for each route group
 internals.buildAPIInfo = function( settings, apiData, slug ){

--- a/public/swaggerui/lib/swagger.js
+++ b/public/swaggerui/lib/swagger.js
@@ -200,9 +200,10 @@
       this.description = resourceObj.description;
       parts = this.path.split("/");
 
-
-      // Modified Glenn 
-      this.name = parts[parts.length - 1].replace('docs?path=', '');
+      var baseDiscovery = api.discoveryUrl.split('/')[1].split('?')[0];
+      var baseReplace = baseDiscovery + '?path=';
+      // Modified Glenn
+      this.name = parts[parts.length - 1].replace(baseReplace, '');
 
 
 

--- a/test/prefix-test.js
+++ b/test/prefix-test.js
@@ -1,0 +1,40 @@
+/*
+Mocha test
+The test was built on Tue Dec 24 2013 13:38:00
+*/
+
+var chai = require('chai'),
+   assert = chai.assert,
+   swagger = require('../lib/index.js');
+
+var internals = swagger._internals;
+
+
+describe('isPrefix test)', function() {
+
+it('isPrefix default', function(){
+    var res = internals._commonPrefix({pathPrefixSize: 1}, '/lala/foo');
+      assert.equal( res, 'lala' );
+});
+
+it('isPrefix nothing', function(){
+    var res = internals._commonPrefix({pathPrefixSize: 1}, '/');
+      assert.equal( res, '' );
+});
+
+it('isPrefix length 2', function(){
+    var res = internals._commonPrefix({pathPrefixSize: 2}, '/lala/foo');
+      assert.equal( res, 'lala/foo' );
+});
+
+it('isPrefix length 2 extra', function(){
+    var res = internals._commonPrefix({pathPrefixSize: 2}, '/lala/foo/blah');
+      assert.equal( res, 'lala/foo' );
+});
+
+it('isPrefix length 2 short route', function(){
+    var res = internals._commonPrefix({pathPrefixSize: 2}, '/lala');
+      assert.equal( res, 'lala' );
+});
+
+});


### PR DESCRIPTION
Hi

Based on our use cases, we have added configurable path prefix sizes to hapi-swagger

What this does is make the endpoints not based uniquely on the first path element but possibly on more elements (for example, suppose you have multiple API versions in your system, or just a common prefix, so you can consider more than one path element for their uniqueness)

While doing this we have come across a bug in swagger.js, in case your discoveryUrl contains something different than docs (in our case it was api-docs) so the replace is based on that and not hardcoded as it is today

Also added a small test file that's running with the other existing tests.
