### PR TITLE
Fixes compatibility with hapi 4.0 and joi 3.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "handlebars": "1.3.x",
     "boom": "2.4.x",
     "hoek": "2.0.x",
-    "joi": "3.0.x"
+    "joi": "3.x.x"
   },
   "devDependencies": {
     "mocha": "1.17.x",


### PR DESCRIPTION
hapi-swagger installed on hapi 4.0 server crashes due to incompatibility between joi 3.0 and 3.1.
A validation object created in hapi-swagger with joi 3.0.x gets evaluated by hapi with joi 3.1.x and server crashes with exception "Alternatives require more than one".
