### PR TITLE
Fixed support for Hapi 4.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,9 @@ var internals = {
         endpoint: '/docs',
         auth: false,
         basePath: '',
-        pathPrefixSize: 1
+        pathPrefixSize: 1,
+        jsonPayload: true,
+        produces: ['application/json']
     }
 };
 
@@ -260,28 +262,32 @@ internals.buildAPIInfo = function(settings, apiData, slug) {
         var queryProperties = internals.validatorsToProperties(route.queryParams && route.queryParams.isJoi ?
                                                                route.queryParams._inner : route.queryParams, 
                                                                swagger.models);
-        var payloadProperty = internals.validatorToProperty(op.nickname, route.payloadParams, swagger.models);
+        var payloadApiParams;
 
-        if (payloadProperty && payloadProperty.type !== 'void') {
-            payloadProperty.required = true;
+        if (settings.jsonPayload) {
+            var payloadProperty = internals.validatorToProperty(op.nickname, route.payloadParams, swagger.models);
+
+            if (payloadProperty && payloadProperty.type !== 'void') {
+                payloadProperty.required = true;
+                // set body type
+                op.consumes = ['application/json'];
+            }
+            payloadApiParams = internals.propertiesToAPIParams({
+                body: payloadProperty
+            }, 'body');
+        } else {
+            var payloadProperties = internals.validatorsToProperties(route.payloadParams && route.payloadParams.isJoi ?
+                                                                     route.payloadParams._inner : route.payloadParams, 
+                                                                     swagger.models);
+            payloadApiParams = internals.propertiesToAPIParams(payloadProperties, 'form');
         }
 
         // add the path, query and body parameters
         op.parameters = op.parameters.concat(
             internals.propertiesToAPIParams(pathProperties, 'path'),
             internals.propertiesToAPIParams(queryProperties, 'query'),
-            internals.propertiesToAPIParams({
-                body: payloadProperty
-            }, 'body')
+            payloadApiParams
         );
-
-        // set body type
-        if (payloadProperty) {
-
-            if (payloadProperty.type !== 'void') {
-                op.consumes = ['application/json'];
-            }
-        }
 
         // set response type and model
         // If the responseSchema is a joi object, response className can be set as an option:
@@ -295,7 +301,7 @@ internals.buildAPIInfo = function(settings, apiData, slug) {
         if (responseProperty) {
             op.type = responseProperty.type || 'void';
             if (op.type !== 'void') {
-                op.produces = ['application/json'];
+                op.produces = settings.produces;
             }
         }
 
@@ -387,7 +393,7 @@ internals.validatorToProperty = function(name, param, models, requiredArray) {
         // add enum values if not only undefined or null
         if (Array.isArray(describe.valids) && describe.valids.length) {
             var enums = describe.valids.filter(function(v) {
-                return v !== undefined;
+                return v !== undefined && v !== '';
             });
             if (enums.length) {
                 property["enum"] = enums;


### PR DESCRIPTION
In Hapi 4.0.1 route.pathParams and route.queryParams are Joi objects. Added a check for that. Also, check for null _settings in params when looking for className.
