### PR TITLE
Added protocol to hapi-swagger settings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var Hoek = require('hoek'),
 
 var internals = {
     defaults: {
-        protocol: null, // If not specified, uses the same protocol as request
+        protocol: null, // If not specified, uses the same protocol as server info
         endpoint: '/docs',
         auth: false,
         basePath: '',


### PR DESCRIPTION
Added ability to specify an external protocol to use for swagger requests (typically https) in the settings if it's different from the protocol of the server (which could be http.)
