### PR TITLE
Add tags parameter to generate specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In the .js file where you create the HAPI `server` object add the following code
 
 ## Tagging your API routes
 As a project may be a mixture of web pages and API endpoints you need to tag the routes you wish Swagger to document. Simply add the `tags: ['api']` property to the route object for any endpoint you want documenting.
+You can even specify more tags and then later generate tag-specific documentation. If you specify `tags: ['api', 'foo']`, you can later use `/docs?tags=foo` to load the documentation on the HTML page (see next section).
 
 
     {
@@ -94,6 +95,15 @@ The doc directory and all the files in the URLs below are added by the plugin
       });
     </script>
 
+If you want to generate tag-specific documentation, you should change the URL from
+
+    url: window.location.protocol + '//' + window.location.host + '/docs',
+
+to:
+
+    url: window.location.protocol + '//' + window.location.host + '/docs?tags=foo,bar,baz',
+
+This will load all routes that have one or more of the given tags (`foo` or `bar` or `baz`).
   
 ### Adding the HTML elements
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,7 @@ internals.docs = function(settings) {
         validate: {
             query: {
                 path: Joi.string(),
+                tags: Joi.string(),
                 api_key: Joi.string()
             }
         },
@@ -115,6 +116,16 @@ internals.docs = function(settings) {
                 });
             }
 
+            // Remove routes without the specified tags if any is specified
+            if (request.query.tags) {
+                tags = request.query.tags.split(',');
+                routes = routes.filter(function(route) {
+                    if (!route.settings.tags || Hoek.intersect(route.settings.tags, tags).length > 0) {
+                        return true;
+                    }
+                    return false;
+                });
+            }
 
             // return 404 if no routes are found
             if (!routes.length) {


### PR DESCRIPTION
This PR resolves #39. By defining multiple tags on a route one can later generate documentation based on that. The query parameter `tags` takes a comma-separated list of values. If one of tags matches, it is returned. But constraint, that each routes must contain the `api` still remains.
