### PR TITLE
Use the basePath from the settings in the endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,11 +93,11 @@ internals.docs = function(settings) {
             // prepend full protocol, hostname and port onto endpoints for shred
             var protocol = requestSettings.protocol || request.server.info.protocol || 'http';
             var hostname = protocol + '://' + request.headers.host;
-            if (!requestSettings.endpoint.match(/^https?:\/\//)) {
-                requestSettings.endpoint = hostname + settings.endpoint;
-            }
             if (!requestSettings.basePath.match(/^https?:\/\//)) {
                 requestSettings.basePath = hostname + settings.basePath;
+            }
+            if (!requestSettings.endpoint.match(/^https?:\/\//)) {
+                requestSettings.endpoint = requestSettings.basePath + settings.endpoint;
             }
 
             var routes = (request.server.routingTable) ? request.server.routingTable() : request.server.table(),


### PR DESCRIPTION
This change ensures that a client of hapi-swagger is able to configure
the API endpoint (including the protocol and host part at the
beginning). Actually it is possible to set the "endpoint" setting, but
because this is used as a path to a route, you are not able to set a
URL.
I think to use the bathPath is actually what a user expects and the
previous behaviour was a bug.
