### PR TITLE
Use settings.auth on swagger assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ exports.register = function(plugin, options, next) {
             method: 'GET',
             path: settings.endpoint + '/swaggerui/index.html',
             config: {
-              auth: settings.aut
+              auth: settings.auth
             },
             handler: {
                 view: {
@@ -65,7 +65,7 @@ exports.register = function(plugin, options, next) {
             method: 'GET',
             path: settings.endpoint + '/swaggerui/{path*}',
             config: {
-              auth: settings.aut
+              auth: settings.auth
             },
             handler: {
                 directory: {


### PR DESCRIPTION
Ran into a problem that when a hapi auth strategy is set as default, auth then becomes required on the swagger asset routes as well. By using the `settings.auth` for the routes added by hapi-swagger, auth can either be disabled (the default behavior) or set to whatever strategy the user wants swagger to employ. 
