### PR TITLE
Improved tag query allows better tag searching with + and - tag prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ internals.docs = function(settings) {
             //         will show routes WITH 'mountains' AND 'beach' AND NO 'horses'
 
             if (request.query.tags) {
-                tags = ['api'].concat(request.query.tags.split(','));
+                tags = request.query.tags.split(',');
                 routes = routes.filter(function(route) {
                     var exit;
 


### PR DESCRIPTION
Adding support for the following tag query prefixes: '-' (exclusionary tags) or '+' (inclusionary tags)
e.g.: ?path=vacations&tags=mountains,beach,horses
        will show routes WITH 'mountains' OR 'beach' OR 'horses'

e.g.: ?path=vacations&tags=mountains,beach,+horses
        will show routes WITH ('mountains' OR 'beach')  AND 'horses'

 e.g.: ?path=vacations&tags=mountains,+beach,-horses
        will show routes WITH 'mountains' AND 'beach' AND NO 'horses'
