### PR TITLE
Model collisions avoided by hashing the object stringify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var Hoek = require('hoek'),
     Boom = require('boom'),
     Joi = require('joi'),
     Path = require('path');
+    Crypto = require('crypto');
 
 // Declare internals
 
@@ -737,7 +738,7 @@ internals.validatorsToModelName = function (name, params, models) {
 
     // if no name create a signature
     if (!name) {
-        name = 'Model_' + Object.keys(params).join('_');
+        name = 'Model_' + Crypto.createHash('md5').update(JSON.stringify(params)).digest('hex');
     }
 
     // find existing model by this name


### PR DESCRIPTION
hotfix uses a md5 of the stringified object when creating an object "signature".  This avoids name space collisions while not duplicating objects in the model.
