### PR TITLE
allow for responseObject to be of type array and returns the proper swagger $ref

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -408,7 +408,7 @@ internals.buildAPIInfo = function (settings, apiData, slug) {
             }
             if(responseProperty.items) {
                 // add these to the api operations
-                api.operations[0].items = responseProperty.items;
+                op.items = responseProperty.items;
             }
         }
 


### PR DESCRIPTION
Currently if the responseObject is an array it returns an object with the keys "includes" and "excludes"
This code change properly processes the responseObject "array" types and returns the appropriate $ref to the model.
