### PR TITLE
changed property.default to property.defaultValue to match swagger-ui

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -514,7 +514,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
         property.description = typeof param._description === 'string' ? param._description : undefined;
         property.notes = typeof param._notes !== 'function' && param._notes.length ? param._notes : undefined;
         property.tags = typeof param._tags !== 'function' && param._tags.length ? param._tags : undefined;
-        property.default = (describe.flags) ? describe.flags.default : null;
+        property.defaultValue = (describe.flags) ? describe.flags.default : null;
 
         if (param._flags && param._flags.presence) {
             property.required = (param._flags.presence === 'required') ? true : false;


### PR DESCRIPTION
I'm brand new to using hapi-swagger (and swagger), but so far it looks awesome. I noticed that on the documentation page for my API, there were no default values for parameters, despite the fact that I was providing defaults via joi's .default(). This one liner fixes the problem. I'm not sure if there is a better approach, but I thought I would put this out there for review..
