### PR TITLE
Fix validation problem on internals.docs to allow swaggerUI to properly load the /docs url without a query present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,11 +98,11 @@ internals.docs = function (settings) {
     return {
         auth: settings.auth,
         validate: {
-            query: {
+            query: Joi.object().keys({
                 path: Joi.string(),
                 tags: Joi.string(),
                 api_key: Joi.string()
-            }
+            })
         },
         handler: function (request, reply) {
 
@@ -489,7 +489,7 @@ internals.validatorsToProperties = function (params, models, requiredArray) {
             properties[key] = internals.validatorToProperty(key, param, models, requiredArray);
             x++;
         }
-    } 
+    }
 
     return properties;
 };
@@ -542,7 +542,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
         }
 
         if (property.type === 'object' && param._inner) {
-            var className = undefined; 
+            var className = undefined;
             var param = (param._inner.children) ? param._inner.children : param._inner
             property.type = internals.validatorsToModelName(
                     className || name || property.description,


### PR DESCRIPTION
I had an issue with swaggerUI not being able to load because it couldn't access the /docs url because of the validation on internals.docs in index.js requiring the query to be present.

To remedy it, I made the query optional by wrapping the query keys in Joi.object().keys()
i.e:

```
validate: {
            query: Joi.object().keys({
                path: Joi.string(),
                tags: Joi.string(),
                api_key: Joi.string()
            })
        },
...
```

I'm using Joi 4.6.2 and Hapi 6.6.0.
