### PR TITLE
[hapi-swagger-80] Allow consumes settings to be changed.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ var internals = {
         pathPrefixSize: 1,
         payloadType: 'json',
         produces: ['application/json'],
+        consumes: ['application/json'],
         ui: true,
         listing: true,
         index: false
@@ -372,7 +373,7 @@ internals.buildAPIInfo = function (settings, apiData, slug) {
             if (payloadProperty && payloadProperty.type !== 'void') {
                 payloadProperty.required = true;
                 // set body type
-                op.consumes = ['application/json'];
+                op.consumes = settings.consumes || ['application/json'];
             }
             payloadApiParams = internals.propertiesToAPIParams({
                 body: payloadProperty


### PR DESCRIPTION
defaults to ['application/json']. gives the UI configurable and
multiple options for data formats to send.

Hapi will allow text data to pass through Content checks if the content-type is text/FOO so the ui should be able to send any text data.
