### PR TITLE
Remove default authorizations to prevent errors on routes with HAPI auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ There are number of options for advance use case. In most case you should only h
 * pathPrefixSize: selects what segment of the URL path is used to group endpoints - the default is: 1
 * payloadType: weather accepts JSON or form parameters for payload - the default is: 'json'
 * produces: an array of the output types from your API - the default is: ['application/json']
-* authorizations: an object containing [swagger authorization objects](https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#515-authorization-object), the keys mapping to hapi authentication. by default an authorization type of apiKey exists passed via the header for all endpoints with auth:true set.
+* authorizations: an object containing [swagger authorization objects](https://github.com/swagger-api/swagger-spec/blob/master/versions/1.2.md#515-authorization-object), the keys mapping to HAPI auth strategy names. No defaults are provided.
 
 
 ### Response Object

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,14 +23,7 @@ var internals = {
         consumes: ['application/json'],
         ui: true,
         listing: true,
-        index: false,
-        authorizations: {
-            default: {
-                type: "apiKey",
-                passAs: "header",
-                keyname: "authentication"
-            }
-        }
+        index: false
     }
 };
 
@@ -257,7 +250,7 @@ internals.getRoutesData = function (routes, settings) {
             responseMessages: routeOptions && routeOptions.responseMessages || []
         };
 
-        if(route.settings.auth) {
+        if(route.settings.auth && settings.authorizations) {
             route.settings.auth.strategies.forEach(function(strategie) {
                 routeData.authorizations[settings.authorizations[strategie].type] = settings.authorizations[strategie]
             });


### PR DESCRIPTION
Pull request #84 introduced a bug. If a route has authentication defined but hapi-swagger authorizations didn't have a matching field then Hapi throws an error when you try to access a path:

http://localhost:3000/docs?path=something

```
141129/065345.304, internalError, message: Uncaught error: Cannot read property 'type' of undefined stack: TypeError: Uncaught error: Cannot read property 'type' of undefined
    at .../node_modules/hapi-swagger/lib/index.js:262:76
```

With this change I fixed it so that, if authorization is not set in hapi-swagger configuration then it's not added to the documentation. This allows us to use authorization methods not supported by swagger (ie, cookies).
