### PR TITLE
Respect classname setting on inner params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,7 @@ internals.getRoutesData = function (routes, settings) {
         if(route.settings.auth && settings.authorizations) {
             route.settings.auth.strategies.forEach(function(strategie) {
                 if(settings.authorizations[strategie] && settings.authorizations[strategie].type){
-                   routeData.authorizations[settings.authorizations[strategie].type] = settings.authorizations[strategie] 
+                   routeData.authorizations[settings.authorizations[strategie].type] = settings.authorizations[strategie]
                 }
             });
         }
@@ -331,6 +331,11 @@ internals._commonPrefix = function (settings, path) {
     prefix = path_head.join('/');
     return prefix;
 };
+
+internals._getClassName = function(schema) {
+  return schema && schema._settings ?
+    schema._settings.className || schema._settings.typeName : undefined;
+}
 
 // build documentation API endpoint for each route group
 internals.buildAPIInfo = function (settings, apiData, slug) {
@@ -414,8 +419,7 @@ internals.buildAPIInfo = function (settings, apiData, slug) {
         // If the responseSchema is a joi object, response className can be set as an option:
         // Example: route.responseSchema = Joi.object({foo:Joi.string()}).options({className:"MyResponseClass"});
 
-        var responseClassName = route.responseSchema && route.responseSchema._settings ?
-            route.responseSchema._settings.className || route.responseSchema._settings.typeName : undefined;
+        var responseClassName = internals._getClassName(route.responseSchema);
 
         var responseProperty = internals.validatorToProperty(responseClassName || op.nickname + '_response',
             internals.getParams(route, 'responseSchema'), swagger.models);
@@ -564,7 +568,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
         }
 
         if (property.type === 'object' && param._inner) {
-            var className = undefined;
+            var className = internals._getClassName(param);
             var param = (param._inner.children) ? param._inner.children : param._inner
             property.type = internals.validatorsToModelName(
                     className || name || property.description,
@@ -597,13 +601,13 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
                     if(arrayProperty.type === 'string'){
                         property.items = {
                             'type': arrayProperty.type
-                        }; 
+                        };
                     }else{
                         property.items = {
                             '$ref': arrayProperty.type
-                        }; 
+                        };
                     }
-        
+
                 }
             }
         }


### PR DESCRIPTION
Right now the model for inner objects come from the name of the
parameter.  This isn’t great, as illustrated in issue #74.  This is
sort of a workaround whereby users can add a classname property on the
validator.

IMO, respecting this field is intuitive behavior.
