### PR TITLE
Add support for custom javascript on the documentation page

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,10 @@ var internals = {
         consumes: ['application/json'],
         ui: true,
         listing: true,
-        index: false
+        index: false,
+        customJSHandler: function(request, reply) {
+          reply('').type('application/javascript');
+        },
     }
 };
 
@@ -64,6 +67,16 @@ exports.register = function (plugin, options, next) {
                 }
             },
             path: __dirname + '/../public/swaggerui'
+        });
+
+
+        plugin.route({
+            method: 'GET',
+            path: settings.endpoint + '/custom.js',
+            config: {
+                auth:settings.auth,
+            },
+            handler: settings.customJSHandler,
         });
 
 
@@ -254,7 +267,7 @@ internals.getRoutesData = function (routes, settings) {
         if(route.settings.auth && settings.authorizations) {
             route.settings.auth.strategies.forEach(function(strategie) {
                 if(settings.authorizations[strategie] && settings.authorizations[strategie].type){
-                   routeData.authorizations[settings.authorizations[strategie].type] = settings.authorizations[strategie] 
+                   routeData.authorizations[settings.authorizations[strategie].type] = settings.authorizations[strategie]
                 }
             });
         }
@@ -597,13 +610,13 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
                     if(arrayProperty.type === 'string'){
                         property.items = {
                             'type': arrayProperty.type
-                        }; 
+                        };
                     }else{
                         property.items = {
                             '$ref': arrayProperty.type
-                        }; 
+                        };
                     }
-        
+
                 }
             }
         }

--- a/public/swaggerui/swagger.html
+++ b/public/swaggerui/swagger.html
@@ -18,6 +18,7 @@
     <script src='/docs/swaggerui/lib/swagger.js' type='text/javascript'></script>
     <script src='/docs/swaggerui/swagger-ui.js' type='text/javascript'></script>
     <script src='/docs/swaggerui/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+    <script src='/docs/custom.js' type='text/javascript'></script>
     <script type="text/javascript">
     $(function() {
 
@@ -59,11 +60,11 @@
                 if(queryStringArray.indexOf('&') > -1){
                     queryStringParamArray = queryStringArray[1].split("&");
                 }
-                for ( var i=0; i<queryStringParamArray.length; i++ ){           
+                for ( var i=0; i<queryStringParamArray.length; i++ ){
                     queryStringNameValueArray = queryStringParamArray[i].split("=");
                     if ( name == queryStringNameValueArray[0] ){
                         nameValue = queryStringNameValueArray[1];
-                    }                       
+                    }
                 }
                 return nameValue;
             }


### PR DESCRIPTION
In order to modify the behavior of the documentation page, it would be
nice to be able to include custom js to the existing page without
copying and changing it wholesale.

This adds a parameter, customJS, which should reply with javascript
(this is empty by default); this javascript will be included with the
documentation page.
