### PR TITLE
Added support for overriding auto-generated nicknames in route config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -269,6 +269,7 @@ internals.getRoutesData = function (routes, settings) {
             responseSchema: route.settings.response && route.settings.response.schema,
             headerParams: route.settings.validate && route.settings.validate.headers,
             responseMessages: routeOptions && routeOptions.responseMessages || [],
+            nickname: routeOptions && routeOptions.nickname || null,
             payloadType: routeOptions && routeOptions.payloadType || null
         };
 
@@ -402,7 +403,7 @@ internals.buildAPIInfo = function (settings, apiData, slug) {
                     "method": route.method,
                     "authorizations": route.authorizations,
                     "summary": route.description,
-                    "nickname": route.path.replace(/\//gi, '').replace(/\{/gi, '').replace(/\}/gi, ''),
+                    "nickname": route.nickname || route.path.replace(/\//gi, '').replace(/\{/gi, '').replace(/\}/gi, ''),
                     "notes": route.notes,
                     "type": 'void',
                     "parameters": []

--- a/test/nickname-test.js
+++ b/test/nickname-test.js
@@ -1,0 +1,72 @@
+/*
+Mocha test
+Tests that note array is broken up correctly
+*/
+
+var chai = require('chai'),
+   Hapi = require('hapi'),
+   assert = chai.assert;
+
+var defaultHandler = function(request, response) {
+  reply('ok');
+};
+
+
+describe('route nickname test', function() {
+
+    var server;
+
+    beforeEach(function(done) {
+    server = new Hapi.Server();
+    server.connection({ host: 'test' });
+    server.register({register: require('../lib/index.js')}, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      server.stop(function() {
+        server = null;
+        done();
+      });
+    });
+
+
+    it('route uses specific nickname if supplied', function(done) {
+      server.route({
+        method: 'GET',
+        path: '/test',
+        handler: defaultHandler,
+        config: {
+          tags: ['api'],
+          plugins: {
+            'hapi-swagger': {
+              nickname: 'getTest'
+            }
+          }
+        }
+      });
+      server.inject({ method: 'GET', url: '/docs?path=test '}, function (response) {
+        var nickname = response.result.apis[0].operations[0].nickname;
+        assert.equal(nickname, 'getTest');
+        done();
+      });
+    });
+
+    it('route generates specific nickname if not supplied', function(done) {
+      server.route({
+        method: 'GET',
+        path: '/test',
+        handler: defaultHandler,
+        config: {
+          tags: ['api']
+        }
+      });
+      server.inject({ method: 'GET', url: '/docs?path=test '}, function (response) {
+        var nickname = response.result.apis[0].operations[0].nickname;
+        assert.equal(nickname, 'test');
+        done();
+      });
+    });
+});


### PR DESCRIPTION
I thought it'd be helpful to be able to override the automatically generated nickname with one provided in the route.

For example:

```
server.route({
    method: 'GET',
    path: '/user/{username}/friends/',
    config: {
        plugins: {
          'hapi-swagger': {
            nickname: 'getFriendsByUsername'
          }
        },
        handler: function(request, reply){
          reply('ok');
        },
        description: 'Get friends for username.',
        notes: ['Returns friends for the provided username.'],
        tags: ['api'],
        validate: {
          params: {
              username: Joi.string()
                      .min(3)
                      .max(10)
                      .required()
                      .description('the username')
          }
      }
    }
});
```
