### PR TITLE
Set the api discovery basepath to the configured basepath

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -303,7 +303,7 @@ internals.buildAPIDiscovery = function (settings, routes, tags) {
         swagger = {
             "apiVersion": "unknown",
             "swaggerVersion": "1.2",
-            "basePath": settings.endpoint + '?path=',
+            "basePath": settings.basePath + '?path=',
             "apis": []
         };
 


### PR DESCRIPTION
... instead of the configured endpoint.

Important for instances wherein hapi-swagger is part of a plugin, which itself is registered with a prefix.