### PR TITLE
Remove the inclusion of the nonexistent readme.css which caused a 404.

### DIFF
--- a/public/swaggerui/swagger.html
+++ b/public/swaggerui/swagger.html
@@ -3,7 +3,6 @@
 <head>
     <meta charset="utf-8">
     <title>Documentation</title>
-    <link rel="stylesheet" type="text/css" href="/css/readme.css" />
     <link href='https://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css' />
     <link href='{{hapiSwagger.endpoint}}/swaggerui/css/highlight.default.css' media='screen' rel='stylesheet' type='text/css' />
     <link href='{{hapiSwagger.endpoint}}/swaggerui/css/screen.css' media='screen' rel='stylesheet' type='text/css' />


### PR DESCRIPTION
I just removed the inclusion of the nonexistent readme.css which caused a 404.
I guess it is unused.