### PR TITLE
Remove an useless call to .build()

### DIFF
--- a/public/swaggerui/swagger-ui.js
+++ b/public/swaggerui/swagger-ui.js
@@ -1253,7 +1253,6 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       this.options.url = url;
       this.headerView.update(url);
       this.api = new SwaggerApi(this.options);
-      this.api.build();
       return this.api;
     };
 


### PR DESCRIPTION
Hi there

The method build() on the SwaggerUi object was called twice and cause two ajax requests. I removed the line because the object call this method during its init (line 44 of swagger.js).