### PR TITLE
Use hapi's server.log() instead of console.log()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ internals.docs = function (settings) {
 
 
             var requestSettings = Hoek.clone(settings);
+            requestSettings.log = request.server.log.bind(request.server);
 
             // prepend full protocol, hostname and port onto endpoints for shred
             var protocol = requestSettings.protocol || request.server.info.protocol || 'http';
@@ -330,7 +331,7 @@ internals.buildAPIDiscovery = function (settings, routes, tags) {
 
         Joi.validate(settings.info, settingsSchema, function (err, value) {
             if(err && err.message){
-                console.log('error hapi-swagger - settings.info:', err.message)
+                settings.log(['error', 'hapi-swagger'], 'settings.info: ' + err.message);
             }else{
                 swagger.info = settings.info; 
             }


### PR DESCRIPTION
If you're using hapi's "good" module to handle centralized logging, information
might get overlooked when pushing it directly to the console. To avoid this,
use the logging method `server.log` provided by the hapi framework itself.