### PR TITLE
Strip unknown fields from settings.info during validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -328,11 +328,11 @@ internals.buildAPIDiscovery = function (settings, routes, tags) {
             licenseUrl: Joi.string().optional()
         });
 
-        Joi.validate(settings.info, settingsSchema, function (err, value) {
+        Joi.validate(settings.info, settingsSchema, { stripUnknown: true }, function (err, value) {
             if(err && err.message){
                 console.log('error hapi-swagger - settings.info:', err.message)
             }else{
-                swagger.info = settings.info; 
+                swagger.info = value;
             }
         }); 
     }


### PR DESCRIPTION
And use the cleaned up `value` parameter instead of `settings.info`.

I'm using the popular [node-config](https://github.com/lorenwest/node-config) module to manage all sorts of hapi configuration option (including parameters for hapi-swagger). Unfortunately it seems to inject additional functions to help merging parts of the configuration options, thus the validation of `settings.info
` will fail. This can easily be fixed by asking Joi to drop all unknown additional keys.