### PR TITLE
Make swagger play with hapi prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,8 @@ var internals = {
         protocol: null, // If not specified, uses the same protocol as server info
         endpoint: '/docs',
         documentationPath: '/documentation',
+        prefix: '', // By default its empty
+        appendedPrefix: false,
         enableDocumentationPage: true,
         auth: false,
         basePath: '',
@@ -813,6 +815,13 @@ internals.appendReplyContext = function ( server, settings ) {
             if(!response.source.context['hapiSwagger']){
                 response.source.context['hapiSwagger'] = {};
             }
+
+            // To adapt to hapi prefix
+            if (!settings.appendedPrefix){
+                settings.appendedPrefix = true;
+                settings.endpoint = settings.prefix + settings.endpoint;
+            }
+
             response.source.context['hapiSwagger'] = settings
         }
 


### PR DESCRIPTION
To make swagger play with hapi prefix. This is done by passing `prefix` on hapi-swagger options.
__Example__:
```javascript
var Hapi   = require( 'hapi' );
var server = new Hapi.server();
var prefix = '/api';

var serverOptions = {
  'routes' : {
    'prefix' : prefix
  }
};

server.connection( {
  'connection' : {
    'port' : 4000    
  }
} );

var plugin = [
  {
    'register' : require( 'my-plugin' )
  },
  {
    'register' : require( 'hapi-swagger' ),
    'options' : {
       'prefix' : prefix
    }
  }
];

server.register( plugins, serverOptions, function () {
  server.start()
} ); 
```

What do you think?