### PR TITLE
Added auth option for fixed path to throbber.gif

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,7 @@ exports.register = function (server, options, next) {
 
         server.route({
             method: 'GET',
-            path: '/docs/swaggerui/images/throbber.gif',
+            path: settings.endpoint + '/swaggerui/images/throbber.gif',
             config: {
                 auth: settings.auth,
             },

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,9 @@ exports.register = function (server, options, next) {
         server.route({
             method: 'GET',
             path: '/docs/swaggerui/images/throbber.gif',
+            config: {
+                auth: settings.auth,
+            },
             handler: function (request, reply) {
                 reply.file( __dirname + '/../public/swaggerui/images/throbber.gif');
             }
@@ -88,7 +91,7 @@ exports.register = function (server, options, next) {
             method: 'GET',
             path: settings.endpoint + '/custom.js',
             config: {
-                auth:settings.auth,
+                auth: settings.auth,
             },
             handler: settings.customJSHandler,
         });


### PR DESCRIPTION
Found out when I browse the documentation on iOS (setup: endpoint: /docs/json; docs auth: none, resources/rest of routes auth: simple) it asks for '/docs/swaggerui/images/throbber.gif' for which auth option is not configurable. Thus if you have global rule to use auth on every route and then disabling auth for documentation (just for viewing) it asks for credentials. No prob on other browsers (Chrome, IE, FF, Edge...)