### PR TITLE
Fix uncaught type error

### DIFF
--- a/public/swaggerui/lib/swagger.js
+++ b/public/swaggerui/lib/swagger.js
@@ -1299,7 +1299,7 @@ var PasswordAuthorization = function(name, username, password) {
   this.password = password;
   this._btoa = null;
   if (typeof window !== 'undefined')
-    this._btoa = btoa;
+    this._btoa = btoa.bind(window);
   else
     this._btoa = require("btoa");
 };


### PR DESCRIPTION
I got an error, if I use the PasswordAuthorization method. Because an illegal invocation. I fixed it, with the binding.