### PR TITLE
Add auth and docs `endpoint` to throbber.gif route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,10 @@ exports.register = function (server, options, next) {
 
         server.route({
             method: 'GET',
-            path: '/docs/swaggerui/images/throbber.gif',
+            path: settings.endpoint + '/swaggerui/images/throbber.gif',
+            config: {
+              auth: settings.auth
+            },
             handler: function (request, reply) {
                 reply.file( __dirname + '/../public/swaggerui/images/throbber.gif');
             }
@@ -88,7 +91,7 @@ exports.register = function (server, options, next) {
             method: 'GET',
             path: settings.endpoint + '/custom.js',
             config: {
-                auth:settings.auth,
+                auth:settings.auth
             },
             handler: settings.customJSHandler,
         });


### PR DESCRIPTION
Thanks for the great plugin! I am not very familiar with Swagger, but look forward to learning more as we use it to document our new API. While getting it set up, I found a non-critical issue with the `throbber.gif` route:

# Background

1. hapi-swagger allows a custom `auth` setting in its plugin options. This setting is applied to all routes that are registered by hapi-swagger. 

1. hapi-swagger allows a custom `endpoint` setting in its plugin options. This setting specifies the base url for the Swagger JSON API, as well as for the SwaggerUI media files (js, css and images). 

# Problem
The auth setting was not applied to the `throbber.gif` route. The path for the route was hardcoded as `/docs/swaggerui/throbber.gif`.

# Solution
Copy the `auth` config settings from the other routes, and place it in the `throbber.gif` route. Also, replace `'/docs` with `settings.endpoint + '`.

# Tests
I re-ran all existing tests, but they do not cover this route. In leu of creating a new test, I functionally verified that this works inside our hapi-swagger implementation. 

