### PR TITLE
fix 'model' variable added to global namespace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -759,7 +759,7 @@ internals.validatorsToModelName = function (name, params, models) {
 
 // creates a new model
 internals.createModel = function (name, params, models) {
-    return model = {
+    return {
         "id": name,
         "type": "object",
         "properties": internals.validatorsToProperties(params, models)


### PR DESCRIPTION
A quick fix to stop the 'model' variable from being added to the global namespace.