### PR TITLE
Add proxy host and proto to basePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ var Hapi            = require('hapi'),
     Pack            = require('./package');
 
 var server = new Hapi.Server();
-server.connection({ 
-        host: 'localhost', 
-        port: 3000 
+server.connection({
+        host: 'localhost',
+        port: 3000
     });
 
 var swaggerOptions = {
@@ -89,7 +89,7 @@ The plugin adds all the resources needed to build the interface into your any pa
 
 ### Adding the javascript
 
-The all the files in the URLs below are added by the plugin, but you must server the custom page as template using `reply.view()`. 
+The all the files in the URLs below are added by the plugin, but you must server the custom page as template using `reply.view()`.
 
 ```html
 <link href='https://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
@@ -167,7 +167,8 @@ Place the HTML code below into the body fo web page where you wish the interface
 There are number of options for advance use case. In most case you should only have to provide the apiVersion.
 
 * `apiVersion`: string The version of your API
-* `basePath`: string The base URL of the API i.e. `http://localhost:3000`
+* `protocol`: e.g. `http` or `https` will override all request heaeders and basePath
+* `basePath`: string The base URL of the API i.e. `http://localhost:3000` (note, this is parsed with `url`, so if you do not specify a protocol, it will be interpreted as path with no hostname).
 * `documentationPath`:  string The path of the documentation page - default: `/documentation`,
 * `enableDocumentationPage`: boolean Enable the the documentation page - default: `true`,
 * `auth`: string The auth strategy to use if enableDocumentationPage is `true` - default: `false`,
@@ -253,7 +254,7 @@ config: {
 }
 ```
 ### File upload
-The plug-in has basic support for file uploads into your API's. Below is an example of a route with a file uplaod, the three important elements are: 
+The plug-in has basic support for file uploads into your API's. Below is an example of a route with a file uplaod, the three important elements are:
 
 * `payloadType: 'form'` in the plugins section creates a form for upload
 * `.meta({ swaggerType: 'file' })` add to the payload property you wish to be file upload
@@ -271,7 +272,7 @@ The plug-in has basic support for file uploads into your API's. Below is an exam
         },
         tags: ['api'],
         validate: {
-            payload: { 
+            payload: {
                 file: Joi.any()
                     .meta({ swaggerType: 'file' })
                     .description('json file')

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,7 +179,7 @@ internals.docs = function (settings) {
             // Treat protocol and host as defaults, and override with requestSettings
             var endpointUrlConfig = Hoek.applyToDefaults(
               urlConfig,
-              Url.parse(requestSettings.basePath)
+              Url.parse(requestSettings.endpoint)
             );
             endpointUrlConfig.protocol = requestSettings.protocol || endpointUrlConfig.protocol;
             requestSettings.endpoint = Url.format(endpointUrlConfig);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@ var Hoek        = require('hoek'),
     Boom        = require('boom'),
     Joi         = require('joi'),
     Path        = require('path'),
-    ShortId     = require('shortid');
+    ShortId     = require('shortid'),
+    Url         = require('url');
 
 
 
@@ -38,16 +39,16 @@ internals.first = function first(array) {
 
 
 exports.register = function (server, options, next) {
-   server.dependency(['inert', 'vision'], after); 
-   return next();  
+   server.dependency(['inert', 'vision'], after);
+   return next();
 }
-    
-    
-var after = function (server, next) {    
+
+
+var after = function (server, next) {
 
     var options = server.realm.pluginOptions,
         settings = Hoek.applyToDefaults(internals.defaults, options || {});
-    
+
     // get the prefix from route options
     settings.prefix = '';
     if(server.realm.modifiers.route.prefix){
@@ -68,7 +69,7 @@ var after = function (server, next) {
     if (settings.enableDocumentationPage) {
         server.route({
             method: 'GET',
-            path: settings.documentationPath,            
+            path: settings.documentationPath,
             config: {
               auth: settings.auth,
             },
@@ -157,15 +158,31 @@ internals.docs = function (settings) {
             var requestSettings = Hoek.clone(settings);
             requestSettings.log = request.server.log.bind(request.server);
 
-            // prepend full protocol, hostname and port onto endpoints for shred
-            var protocol = requestSettings.protocol || request.server.info.protocol || 'http';
-            var hostname = protocol + '://' + request.headers.host;
-            if (!requestSettings.basePath.match(/^https?:\/\//)) {
-                requestSettings.basePath = hostname + settings.basePath;
-            }
-            if (!requestSettings.endpoint.match(/^https?:\/\//)) {
-                requestSettings.endpoint = requestSettings.basePath + settings.endpoint;
-            }
+            // get protocol and host from request
+            var protocol = request.headers['x-forwarded-proto'] ||
+              request.server.info.protocol ||
+              'http';
+            var host = request.headers['x-forwarded-host'] || request.headers.host;
+            var urlConfig = {
+              protocol: protocol,
+              host: host
+            };
+
+            // Treat protocol and host as defaults, and override with requestSettings
+            var baseUrlConfig = Hoek.applyToDefaults(
+              urlConfig,
+              Url.parse(requestSettings.basePath)
+            );
+            baseUrlConfig.protocol = requestSettings.protocol || baseUrlConfig.protocol;
+            requestSettings.basePath = Url.format(baseUrlConfig);
+
+            // Treat protocol and host as defaults, and override with requestSettings
+            var endpointUrlConfig = Hoek.applyToDefaults(
+              urlConfig,
+              Url.parse(requestSettings.basePath)
+            );
+            endpointUrlConfig.protocol = requestSettings.protocol || endpointUrlConfig.protocol;
+            requestSettings.endpoint = Url.format(endpointUrlConfig);
 
             var routes = request.server.table()[0].table,
                 resourceName = request.query.path;
@@ -281,13 +298,13 @@ internals.isResourceRoute = function (routePath, resourceName) {
 // filters route objects into simpler more useful form
 internals.getRoutesData = function (routes, settings) {
     var routesData = [];
-    
-    
+
+
     "GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"
     routes.forEach(function (route) {
-        
+
     })
-    
+
 
     routes.forEach(function (route) {
         // only include routes tagged with "api"
@@ -318,26 +335,26 @@ internals.getRoutesData = function (routes, settings) {
                 }
             });
         }
-        
+
         // hapi wildcard or array support for methods
         if(routeData.method === '*' || Array.isArray(routeData.method)){
             // OPTIONS not supported by Swagger and HEAD not support by HAPI
             var methods = ["GET", "POST", "PUT", "PATCH", "DELETE"];
-            
+
             if(Array.isArray(routeData.method)){
                 methods = routeData.method.filter(function( value ){
                     return (value.toUpperCase() !== "OPTIONS" || value.toUpperCase() !== "HEAD");
                 });
             }
-            
+
             methods.forEach(function (method) {
                 var newRoute = Hoek.clone( routeData );
                 newRoute.method = method.toUpperCase();;
                 routesData.push(newRoute);
             });
-            
+
         }else{
-           routesData.push(routeData); 
+           routesData.push(routeData);
         }
     });
 
@@ -388,7 +405,7 @@ internals.buildAPIDiscovery = function (settings, routes, tags) {
             }else{
                 swagger.info = value;
             }
-        }); 
+        });
     }
 
     while (x < i) {
@@ -438,7 +455,7 @@ internals._getClassName = function(schema) {
             if(schema._meta[i].className){
                 return schema._meta[i].className
             }
-        }    
+        }
     }
     return undefined;
 }
@@ -532,8 +549,8 @@ internals.buildAPIInfo = function (settings, apiData, slug) {
 
         var responseProperty = internals.validatorToProperty(
                 responseClassName,
-                internals.getParams(route, 'responseSchema'), 
-                swagger.models, 
+                internals.getParams(route, 'responseSchema'),
+                swagger.models,
                 null
             );
 
@@ -642,7 +659,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
     }
 
     // removes forbidden properties
-    if (param._flags 
+    if (param._flags
         && param._flags.presence
         && param._flags.presence === 'forbidden'){
             return undefined;
@@ -708,7 +725,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
 
             if (firstInclusionType) {
                 // get className of embeded array
-                if(name === 'items' 
+                if(name === 'items'
                     && Hoek.reach(param, '_inner.inclusions.0._meta')
                     && Array.isArray(param._inner.inclusions[0]._meta)){
 
@@ -718,7 +735,7 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
                         if(meta[i].className){
                             name = meta[i].className
                         }
-                    }    
+                    }
                 }
 
 
@@ -744,16 +761,16 @@ internals.validatorToProperty = function (name, param, models, requiredArray) {
             }
         }
 
-        if (property.type === 'any') { 
+        if (property.type === 'any') {
             var i = param._meta.length;
             while (i--) {
                 if(param._meta[i].swaggerType
                     && param._meta[i].swaggerType === 'file'){
-                    property.type = "file";  
-                    property.paramType = "body"; 
+                    property.type = "file";
+                    property.paramType = "body";
                 }
-            }    
-        } 
+            }
+        }
 
     }
 
@@ -783,11 +800,11 @@ internals.validatorsToModelName = function (name, params, models) {
     // find existing model by this name
     var foundModel = models[name];
     if (foundModel) {
-        
+
         // deep compare object
         if(Hoek.deepEqual(foundModel, model)){
             // return existing id
-            return foundModel.id; 
+            return foundModel.id;
         }else{
             // create new model with alt name, to stop reuse of model
             model.id = 'model_' + ShortId.generate();

--- a/test/base-path-test.js
+++ b/test/base-path-test.js
@@ -1,0 +1,176 @@
+/*
+Mocha test
+Tests that note array is broken up correctly
+*/
+
+var Chai            = require('chai'),
+Hapi            = require('hapi'),
+Joi             = require('joi'),
+Inert           = require('inert'),
+Vision          = require('vision'),
+HapiSwagger     = require('../lib/index.js');
+assert          = Chai.assert;
+
+
+var defaultHandler = function(request, response) {
+  reply('ok');
+};
+
+
+describe('basePath', function() {
+
+  var pluginConfig = {
+    register: HapiSwagger,
+    options: {
+      basePath: 'http://testhost'
+    }
+  };
+
+  var requestOptions = {
+    method: 'GET',
+    url: '/docs?path=test',
+    headers: {
+      host: 'localhost'
+    }
+  };
+
+  var server;
+
+  var initServer = function(hapiSwaggerConfig, done) {
+    server = new Hapi.Server();
+    server.connection();
+    server.route({
+      method: 'GET',
+      path: '/test',
+      handler: defaultHandler,
+      config: {
+        tags: ['api']
+      }
+    });
+    server.register([Inert, Vision, hapiSwaggerConfig], function(err){
+      server.start(function(err){
+        assert.ifError(err);
+        done();
+      });
+    });
+  };
+
+  afterEach(function(done) {
+    server.stop(function() {
+      server = null;
+      done();
+    });
+  });
+
+  describe('basePath option', function() {
+    before('init server', function(done){
+      pluginConfig.options = {
+        basePath: 'http://testhost/'
+      };
+      initServer(pluginConfig, done);
+    });
+
+    it('should use the basePath option if specified', function(done) {
+      server.inject(requestOptions, function (response) {
+        assert.equal(response.result.basePath, pluginConfig.options.basePath);
+        done();
+      });
+    });
+  });
+
+  describe('protocol option', function() {
+    before('init server', function(done){
+      pluginConfig.options = {
+        basePath: 'http://testhost/',
+        protocol: 'https'
+      };
+      initServer(pluginConfig, done);
+    });
+
+    it('should use the protocol option if specified', function(done) {
+      var expectedBasePath = [
+        pluginConfig.options.protocol,
+        '://',
+        pluginConfig.options.basePath.replace(/http:\/\//,'')
+      ].join('');
+
+      server.inject(requestOptions, function (response) {
+        assert.equal(response.result.basePath, expectedBasePath);
+        done();
+      });
+    });
+  });
+
+  describe('request host', function() {
+
+    before('init server', function(done){
+      pluginConfig.options = {};
+      initServer(pluginConfig, done);
+    });
+
+    it('should use the request.headers.host if no basePath specified', function(done) {
+      requestOptions.headers = {
+        host: 'testtwo'
+      };
+
+      server.inject(requestOptions, function (response) {
+        var expectedBasePath = [
+          'http://',
+          requestOptions.headers.host
+        ].join('');
+        assert.equal(response.result.basePath, expectedBasePath);
+        done();
+      });
+    });
+  });
+
+  describe('proxy forwarded host', function() {
+
+    before('init server', function(done){
+      pluginConfig.options = {};
+      initServer(pluginConfig, done);
+    });
+
+    it('should use the x-forwarded-host if no basePath specified', function(done) {
+      requestOptions.headers = {
+        host: 'testtwo',
+        'x-forwarded-host': 'proxyhost'
+      };
+
+      server.inject(requestOptions, function (response) {
+        var expectedBasePath = [
+          'http://',
+          requestOptions.headers['x-forwarded-host']
+        ].join('');
+        assert.equal(response.result.basePath, expectedBasePath);
+        done();
+      });
+    });
+  });
+
+  describe('proxy forwarded proto', function() {
+
+    before('init server', function(done){
+      pluginConfig.options = {};
+      initServer(pluginConfig, done);
+    });
+
+    it('should use the request.headers.x-forwarded-proto if no protocol specified', function(done) {
+      requestOptions.headers = {
+        'x-forwarded-host': 'proxyhost',
+        'x-forwarded-proto': 'https'
+      };
+
+      server.inject(requestOptions, function (response) {
+        var expectedBasePath = [
+          requestOptions.headers['x-forwarded-proto'],
+          '://',
+          requestOptions.headers['x-forwarded-host']
+        ].join('');
+
+        assert.equal(response.result.basePath, expectedBasePath);
+        done();
+      });
+    });
+  });
+});

--- a/test/base-path-test.js
+++ b/test/base-path-test.js
@@ -173,4 +173,32 @@ describe('basePath', function() {
       });
     });
   });
+
+  describe('endpoint', function() {
+
+    before('init server', function(done){
+      pluginConfig.options = {};
+      initServer(pluginConfig, done);
+    });
+
+    it('should still set the proper endpoint', function(done) {
+      requestOptions.headers = {
+        'x-forwarded-host': 'proxyhost',
+        'x-forwarded-proto': 'https'
+      };
+      requestOptions.url = '/docs';
+
+      server.inject(requestOptions, function (response) {
+        var expectedBasePath = [
+          requestOptions.headers['x-forwarded-proto'],
+          '://',
+          requestOptions.headers['x-forwarded-host'],
+          '/docs?path='
+        ].join('');
+
+        assert.equal(response.result.basePath, expectedBasePath);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Thanks again for the awesome repo! Our hapi API lives behind a reverse proxy, so it is important that all of the URLs generated by the swagger docs use the protocol and port in the `x-forwarded` headers. 

Accomplishing this was fairly simple, but in the process of writing tests, I found that it was difficult to reason about how `requestSettings.baseUrl` was defined. For instance, if `options.protocol` was set in the plugin options, and `options.baseUrl` was also set, then `options.baseUrl` would override `options.protocol`. Further, there were cases where `options.baseUrl` would be appended to the hostname derived from the headers.

Based on this behavior, I decided to rewrite how `baseUrl`is derived. I used the `url` native Node utility to parse the `options.baseUrl`, and override each component of the URL individually (e.g. the protocol, the host, the path, etc...). 

While I hope that you agree with my changes, the most important thing to me is that the `x-forwarded` headers be used to determine the `baseUrl`. Feel free to send it back to me, and I will send you a dead simple PR with only the `x-forwarded` headers changes applied. 

Thank you.