### PR TITLE
Fixes glennjones/hapi-swagger#145

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,7 @@ internals.docs = function (settings) {
             endpointUrlConfig.protocol = requestSettings.protocol || endpointUrlConfig.protocol;
             requestSettings.endpoint = Url.format(endpointUrlConfig);
 
-            var routes = request.server.table()[0].table,
+            var routes = request.connection.table(),
                 resourceName = request.query.path;
 
 


### PR DESCRIPTION
Fixes glennjones/hapi-swagger#145

In Hapi >= 9, the `request` has a `connection` property with method `table()` that returns the `table` object for that connection. The previous version of the code would select the first labeled connection instead of the connection passed to the plugin.