### PR TITLE
Allow specifying payload params for proxy handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -320,7 +320,8 @@ internals.getRoutesData = function (routes, settings) {
             tags: route.settings.tags,
             queryParams: route.settings.validate && route.settings.validate.query,
             pathParams: route.settings.validate && route.settings.validate.params,
-            payloadParams: route.settings.validate && route.settings.validate.payload,
+            payloadParams: route.settings.validate && route.settings.validate.payload ||
+              routeOptions && routeOptions.validate && routeOptions.validate.payload,
             responseSchema: route.settings.response && route.settings.response.schema,
             headerParams: route.settings.validate && route.settings.validate.headers,
             responseMessages: routeOptions && routeOptions.responseMessages || [],

--- a/test/prefix-test.js
+++ b/test/prefix-test.js
@@ -72,6 +72,7 @@ describe('prefix', function() {
   describe('first segment', function() {
 
       beforeEach(function(done) {
+        server.route(routes);
         server.register([
           Inert, 
           Vision, 
@@ -81,10 +82,9 @@ describe('prefix', function() {
           }], function(err){
           server.start(function(err){
             assert.ifError(err);
+            done();
           });
         });
-        server.route(routes);
-        done();
       });
       
       it('GET method added', function(done) {
@@ -101,6 +101,7 @@ describe('prefix', function() {
   describe('second segment', function() {
 
       beforeEach(function(done) {
+        server.route(routes);
         server.register([
           Inert, 
           Vision, 
@@ -110,10 +111,9 @@ describe('prefix', function() {
           }], function(err){
           server.start(function(err){
             assert.ifError(err);
+            done();
           });
         });
-        server.route(routes);
-        done();
       });
       
    


### PR DESCRIPTION
hapi doesn't allow specifying payload validation for proxy handler as payloads are not parsed for these. 

@hueniverse suggest this [should be plugin specific config](https://github.com/hapijs/hapi/issues/2260#issuecomment-65923893) in this case (like response schemas). 

With my change we try to read payload params from plugin specific config when it's not found under validate config.