### PR TITLE
fix 500 response if regex control chars in path param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -288,7 +288,7 @@ internals.docs = function (settings) {
 internals.isResourceRoute = function (routePath, resourceName) {
     if (routePath &&
         resourceName &&
-        routePath.search('^/' + resourceName + '(/|$)') === 0) {
+        routePath.search('^/' + resourceName.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '(/|$)') === 0) {
         return true;
     }
     return false;


### PR DESCRIPTION
Client-provided variable should be escaped before in use for regex. Leads otherwise to syntax errors if it results in an invalid regex, e.g. `/docs?path=foo(`

Credit for escape regex to bobince on http://stackoverflow.com/a/3561711/134162