### PR TITLE
Fix casing for `Pack`  variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ server.connection({
     });
 
 var swaggerOptions = {
-        apiVersion: pack.version
+        apiVersion: Pack.version
     };
 
 server.register([


### PR DESCRIPTION
The mis-matched case prevents the example from working out of the box.