### PR TITLE
Pass through basepath into endpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -183,7 +183,7 @@ internals.docs = function (settings) {
             // Treat protocol and host as defaults, and override with requestSettings
             var endpointUrlConfig = Hoek.applyToDefaults(
               urlConfig,
-              Url.parse(requestSettings.endpoint)
+              Url.parse(internals.removeTrailingSlash(requestSettings.basePath) + requestSettings.endpoint)
             );
             endpointUrlConfig.protocol = requestSettings.protocol || endpointUrlConfig.protocol;
             requestSettings.endpoint = Url.format(endpointUrlConfig);


### PR DESCRIPTION
This fixes a particular case I have, where the hapi routes sit behind a proxy, and the baseURL is on a different host.

Currently the basePath specified is not prepended to the endpoint, so when accessing the swagger-ui the XHR request is going to the hapijs host which is not accessible from in front of the proxy.

I have tested this locally with and without a basePath, and it seems to work as expected.

If you think that this is the right approach, let me know and I will create some tests.

Thanks