### PR TITLE
Remove the need for inert and vision when doc endpoint is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hapi-swagger
 
-This is a [Swagger UI](https://github.com/wordnik/swagger-ui) plug-in for [HAPI](http://hapijs.com/) v9.x to v11.x  When installed it will self document HTTP API interface in a project.
+This is a [Swagger UI](https://github.com/wordnik/swagger-ui) plug-in for [HAPI](http://hapijs.com/) v9.x to v12.x  When installed it will self document HTTP API interface in a project.
 
 [![build status](https://img.shields.io/travis/glennjones/hapi-swagger.svg?style=flat-square)](http://travis-ci.org/glennjones/hapi-swagger)
 [![Coverage Status](https://img.shields.io/coveralls/glennjones/hapi-swagger/dev.svg?style=flat-square)](https://coveralls.io/r/glennjones/hapi-swagger)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ You can add the module to your HAPI using npm:
 
     $ npm install hapi-swagger --save
 
-You will also need to install the `inert` and `vision` plugs-ins which support templates and static content serving.
+If you want to view the documentation from your API you will also need to install the `inert` and `vision` plugs-ins which support templates and static content serving.
+
+This is not required if to generate a swagger.json for use in a different documentation site
+or swagger-codegen simply set `enableDocumentation` to false
 
     $ npm install inert --save
     $ npm install vision --save

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,24 +52,6 @@ exports.register = function (plugin, options, next) {
     const settings = Hoek.applyToDefaults(defaults, options);
     const swaggerDirPath = __dirname + Path.sep + '..' + Path.sep + 'public' + Path.sep + 'swaggerui';
 
-    // There is no way to cover this differs from Hapi 9 to 10+
-    /* $lab:coverage:off$ */
-    if (plugin.registrations){
-        Hoek.assert(plugin.registrations.vision, 'Missing vision plug-in registation');
-        Hoek.assert(plugin.registrations.inert, 'Missing inert plug-in registation');
-    }
-    /* $lab:coverage:on$ */
-
-    // add routing for swaggerui static assets /swaggerui/
-    plugin.views({
-        engines: {
-            html: {
-                module: require('handlebars')
-            }
-        },
-        path: swaggerDirPath
-    });
-
     // add routing swagger json
     plugin.route([{
         method: 'GET',
@@ -90,6 +72,25 @@ exports.register = function (plugin, options, next) {
 
     // add routing for swagger ui
     if (settings.enableDocumentation === true) {
+
+        // There is no way to cover this differs from Hapi 9 to 10+
+        /* $lab:coverage:off$ */
+        if (plugin.registrations){
+            Hoek.assert(plugin.registrations.vision, 'Missing vision plug-in registation');
+            Hoek.assert(plugin.registrations.inert, 'Missing inert plug-in registation');
+        }
+        /* $lab:coverage:on$ */
+
+        // add routing for swaggerui static assets /swaggerui/
+        plugin.views({
+            engines: {
+                html: {
+                    module: require('handlebars')
+                }
+            },
+            path: swaggerDirPath
+        });
+
         plugin.route([{
             method: 'GET',
             path: settings.documentationPath,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "test-cov-coveralls": "./node_modules/.bin/lab -r lcov | ./node_modules/.bin/coveralls"
   },
   "peerDependencies": {
-    "hapi": "^9.0.1 || ^10.0.0 || ^11.0.0"
+    "hapi": "^9.0.1 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   }
 }


### PR DESCRIPTION
I love the plugin. However I don't need a documentation page on my API and I have no need for inert or vision in my API. So I have simply move the plugin check and view config inside of the check for "documentationEnabled" this way I can point API Gateway at the generated swagger.json for documentation and have my CI download the swagger.json for use in swagger-codegen

If there are any changes you want me to make or any concerns about this PR please just let me know