### PR TITLE
Add support for array responses

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -39,7 +39,7 @@ responses.build = function (userDefindedObjs, defaultSchema, statusSchemas, defi
                 out[key].example = Utilities.getJoiMetaProperty(statusSchemas[key], 'example');
 
                 // only add schema if object has children
-                if (Utilities.hasJoiChildren(statusSchemas[key])) {
+                if (Utilities.hasJoiChildren(statusSchemas[key]) || Utilities.isJoiArray(statusSchemas[key])) {
                     out[key] = {
                         schema: {
                             '$ref': '#/definitions/' + Definitions.appendJoi(responseName, statusSchemas[key], definitionCollection, operationId + '_' + key)

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -97,6 +97,18 @@ utilities.hasJoiChildren = function (joiObj) {
 
 
 /**
+ * is a JOI array representation
+ *
+ * @param  {Object} joiObj
+ * @return {Boolean}
+ */
+utilities.isJoiArray = function (joiObj) {
+
+    return (utilities.isJoi(joiObj) && Hoek.reach(joiObj,'_type') === 'array');
+};
+
+
+/**
  * checks if object has meta array
  *
  * @param  {Object} joiObj

--- a/test/utilities-test.js
+++ b/test/utilities-test.js
@@ -81,6 +81,17 @@ lab.experiment('utilities', () => {
     });
 
 
+    lab.test('isJoiArray', (done) => {
+
+        expect(Utilities.isJoiArray({})).to.equal(false);
+        expect(Utilities.isJoiArray(Joi.object())).to.equal(false);
+        expect(Utilities.isJoiArray(Joi.array().items({
+            id: Joi.string()
+        }))).to.equal(true);
+        done();
+    });
+
+
     lab.test('hasJoiMeta', (done) => {
 
         expect(Utilities.hasJoiMeta({})).to.equal(false);


### PR DESCRIPTION
Add supports for arrays at the root of the responses. This was previously supported by hapi-swagger v2, and was a breaking change for us.