### PR TITLE
#fix keys were replaced by labels

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -83,12 +83,13 @@ properties.parseProperties = function (joiObj, definitionCollection, type) {
         joiObj.forEach( (obj) => {
 
             let name = obj.key;
+            let definitionName = name;
             let joiChildObj = obj.schema;
             // get name form label if set
             if (Hoek.reach(joiChildObj, '_settings.language.label')) {
-                name = Hoek.reach(joiChildObj, '_settings.language.label');
+                definitionName = Hoek.reach(joiChildObj, '_settings.language.label');
             }
-            propertiesObj[name] = properties.parseProperty(name, joiChildObj, definitionCollection, type);
+            propertiesObj[name] = properties.parseProperty(definitionName, joiChildObj, definitionCollection, type);
         });
     }
 

--- a/test/properties.js
+++ b/test/properties.js
@@ -276,7 +276,7 @@ lab.experiment('property - ', () => {
 
         // this example has both child object labels and array labels
 
-        let definatition = {};
+        let definition = {};
         const parsed = Properties.parseProperties(
             Joi.object().keys( {
                 ans_list: Joi.array().items(
@@ -285,10 +285,10 @@ lab.experiment('property - ', () => {
                         v2: Joi.number()
                     } ).label('ans-o')
                 ).label('ans-l')
-            } ).label('ans-parent'), definatition, 'query');
+            } ).label('ans-parent'), definition, 'query');
 
         const parsedExpected = {
-            'ans-l': {
+            'ans_list': {
                 type: 'array',
                 items: {
                     '$ref': '#/definitions/ans-o'
@@ -296,7 +296,7 @@ lab.experiment('property - ', () => {
                 collectionFormat: 'multi'
             }
         };
-        const definatitionExpected = {
+        const definitionExpected = {
             'ans-o': {
                 'type': 'object',
                 'properties': {
@@ -311,7 +311,7 @@ lab.experiment('property - ', () => {
         };
 
         expect(parsed).to.deep.equal(parsedExpected);
-        expect(definatition).to.deep.equal(definatitionExpected);
+        expect(definition).to.deep.equal(definitionExpected);
 
         done();
     });


### PR DESCRIPTION
```js
let user = Joi.schema({ {
         name:Joi.string()
}).label('User')

let schema = Joi.schema({
     createdBy:User,
     editedBy:User
})
```
would have become in the /docs page:
```js
definition {
   User:User
}
User {
   name:"string"
}
```
after fix will stay
```js
definition {
   createdBy:User,
   editedBy:User
}
User {
   name:"string"
}
```


parse label should reflect to definition name only, and not change the properties key