### PR TITLE
Ignore allow(null) on properties, per OpenAPI spec.

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -152,7 +152,7 @@ properties.parseProperty = function (name, joiObj, definitionCollection, type) {
         // fliter out empty values and arrays
         var enums = describe.valids.filter( (item) => {
 
-            return item !== '';
+            return item !== '' && item !== null;
         });
         if (enums.length > 0) {
             property.enum = enums;

--- a/test/properties.js
+++ b/test/properties.js
@@ -212,6 +212,7 @@ lab.experiment('property - ', () => {
         expect(Properties.parseProperty('x', Joi.number().allow(1,2,3,4,5))).to.deep.equal({ 'type': 'number', 'enum': [1,2,3,4,5] });
         expect(Properties.parseProperty('x', Joi.string().allow('decimal', 'binary', ''))).to.deep.equal({ 'type': 'string', 'enum': ['decimal', 'binary'] });
         expect(Properties.parseProperty('x', Joi.string().allow(''))).to.deep.equal({ 'type': 'string' });
+        expect(Properties.parseProperty('x', Joi.string().allow(null))).to.deep.equal({ 'type': 'string' });
 
         //console.log(JSON.stringify(Properties.parseProperty('x', Joi.array().allow('a','b','c'), {}, 'query')))
         expect(Properties.parseProperty('x', Joi.array().allow('a', 'b', 'c'), {}, 'query')).to.deep.equal({


### PR DESCRIPTION
See #212 for details.  Basically– `null` isn't allowed in an `enum` field per the OpenAPI spec, so we're not going to put it there :)