### PR TITLE
added support for apiKey authorization

### DIFF
--- a/public/swaggerui/index.html
+++ b/public/swaggerui/index.html
@@ -30,117 +30,124 @@
 
     <script type="text/javascript">
         $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
-      if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
-      } else {
-        url = "{{{hapiSwagger.jsonPath}}}";
-      }
+            var url = window.location.search.match(/url=([^&]+)/);
+            if (url && url.length > 1) {
+                url = decodeURIComponent(url[1]);
+            } else {
+                url = "{{{hapiSwagger.jsonPath}}}";
+            }
 
-      // Pre load translate...
-      if(window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
-      }
+            // Pre load translate...
+            if(window.SwaggerTranslator) {
+                window.SwaggerTranslator.translate();
+            }
 
-      // pull validatorUrl string or null form server
-      var validatorUrl = null;
-      {{#if hapiSwagger.validatorUrl}}
-      validatorUrl: '{{hapiSwagger.validatorUrl}}';
-      {{/if}}
+            // pull validatorUrl string or null form server
+            var validatorUrl = null;
+            {{#if hapiSwagger.validatorUrl}}
+            validatorUrl: '{{hapiSwagger.validatorUrl}}';
+            {{/if}}
 
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function(swaggerApi, swaggerUi){
-          if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: ","
-            });
-          }
+            var auth=null;
 
-          if(window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
-          }
+            window.swaggerUi = new SwaggerUi({
+                url: url,
+                dom_id: "swagger-ui-container",
+                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+                onComplete: function(swaggerApi, swaggerUi){
+                    if(typeof initOAuth == "function") {
+                        initOAuth({
+                            clientId: "your-client-id",
+                            clientSecret: "your-client-secret",
+                            realm: "your-realms",
+                            appName: "your-app-name",
+                            scopeSeparator: ","
+                        });
+                    }
 
-          $('pre code').each(function(i, e) {
-            hljs.highlightBlock(e)
-          });
+                    if(window.SwaggerTranslator) {
+                        window.SwaggerTranslator.translate();
+                    }
 
-          //addApiKeyAuthorization();
-        },
-        onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "{{hapiSwagger.expanded}}",
-        apisSorter: apisSorter.{{hapiSwagger.sortTags}},
-        operationsSorter: operationsSorter.{{hapiSwagger.sortEndpoints}},
-        showRequestHeaders: false,
-        validatorUrl: validatorUrl
-      });
+                    $('pre code').each(function(i, e) {
+                        hljs.highlightBlock(e)
+                    });
 
-
-     /*
-
-      function addApiKeyAuthorization(){
-        var key = encodeURIComponent($('#input_apiKey')[0].value);
-        if(key && key.trim() != "") {
-            var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("authorization", key, "header");
-            window.swaggerUi.api.clientAuthorizations.add("authorization", apiKeyAuth);
-            log("added key " + key);
-        }
-      }
+                    if(Array.isArray(swaggerApi.auths) && swaggerApi.auths.length > 0 && swaggerApi.auths[0].type==="apiKey"){
+                        auth = swaggerApi.auths[0].value
+                        $('#input_apiKey').show()
+                    }
+                    //addApiKeyAuthorization();
+                },
+                onFailure: function(data) {
+                    log("Unable to Load SwaggerUI");
+                },
+                docExpansion: "{{hapiSwagger.expanded}}",
+                apisSorter: apisSorter.{{hapiSwagger.sortTags}},
+            operationsSorter: operationsSorter.{{hapiSwagger.sortEndpoints}},
+            showRequestHeaders: false,
+                    validatorUrl: validatorUrl
+        });
 
 
-      $('#input_apiKey').change(addApiKeyAuthorization);
 
 
-      // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
-
-      var apiKey = "Bearer 12345";
-      $('#input_apiKey').val(apiKey);
-
-      */
-
-
-      window.swaggerUi.load();
-
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
-      }
-  });
+            function addApiKeyAuthorization(){
+                var key = encodeURIComponent($('#input_apiKey')[0].value);
+                if(key && key.trim() != "") {
+                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(auth.name, key, auth.in);
+                    window.swaggerUi.api.clientAuthorizations.add(auth.name, apiKeyAuth);
+                    log("added key " + key);
+                }
+            }
 
 
-    // creates a list of tags in the order they where created
-    var tags = []
-    {{#each hapiSwagger.tags}}
-    tags.push('{{name}}');
-    {{/each}}
+            $('#input_apiKey').change(addApiKeyAuthorization);
+            /*
+
+             // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
+
+             var apiKey = "Bearer 12345";
+             $('#input_apiKey').val(apiKey);
+
+             */
+
+
+            window.swaggerUi.load();
+
+            function log() {
+                if ('console' in window) {
+                    console.log.apply(console, arguments);
+                }
+            }
+        });
+
+
+        // creates a list of tags in the order they where created
+        var tags = []
+        {{#each hapiSwagger.tags}}
+        tags.push('{{name}}');
+        {{/each}}
     </script>
 </head>
 
 <body class="swagger-section">
-    <div id='header'>
-        <div class="swagger-ui-wrap">
-            <a id="logo" href="http://swagger.io">swagger</a>
-            <form id='api_selector'>
-                <!--
-      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
-      <div class='input'><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
-      <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
-      -->
-            </form>
-        </div>
-    </div>
+<div id='header'>
+    <div class="swagger-ui-wrap">
+        <a id="logo" href="http://swagger.io">swagger</a>
+        <form id='api_selector' onsubmit="return false">
+            <div class='input'><input placeholder="api_key" id="input_apiKey" style="display:none" name="apiKey" type="text"/></div>
+            <!--
+  <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
 
-    <div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
-    <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+  <div class='input'><a id="explore" href="#" data-sw-translate>Explore</a></div>
+  -->
+        </form>
+    </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
 </body>
 
 </html>


### PR DESCRIPTION
added support for securityDefinitions apiKey

example swagger options with added securityDefinitions & security
```js
const swaggerOptions = {
    basePath           : '/api/v1/',
    pathPrefixSize     : 3,
    documentationPath  : '/docs',
    swaggerUIPath      : '/docs/swaggerui/',
    jsonPath           : '/docs/swagger.json',
    securityDefinitions: {
        "Bearer": {
            "type": "apiKey",
            "name": "Authorization",
            "in"  : "header"
        }
    },
    security           : [{'Bearer': []}],
    validatorUrl       : null,
};
```

header activates input for api_key

<img width="983" alt="screen shot 2016-02-05 at 11 55 36" src="https://cloud.githubusercontent.com/assets/787730/12843046/6f7b23ee-cbff-11e5-8b84-21d2ea6be934.png">


and with security commented out

<img width="1040" alt="screen shot 2016-02-05 at 11 56 44" src="https://cloud.githubusercontent.com/assets/787730/12843078/9e992586-cbff-11e5-8154-77da567494e3.png">

