### PR TITLE
Use x-arr-ssl header to find requested protocol

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -128,7 +128,7 @@ builder.dereference = function (schema, callback) {
  */
 internals.getHost = function (request) {
 
-    return request.headers['x-forwarded-host'] || request.headers.host;
+    return request.headers['x-forwarded-host'] || request.headers['disguised-host'] || request.headers.host;
 };
 
 
@@ -140,7 +140,13 @@ internals.getHost = function (request) {
  */
 internals.getSchema = function (request) {
 
-    return request.headers['x-forwarded-proto'] || request.connection.info.protocol;
+    const forwardedProtocol = request.headers['x-forwarded-proto'];
+
+    if (request.headers['x-arr-ssl'] && !forwardedProtocol) {
+        return 'https';
+    }
+
+    return forwardedProtocol || request.connection.info.protocol;
 };
 
 

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -94,6 +94,29 @@ lab.experiment('proxies', () => {
     });
 
 
+    lab.test('Azure Web Sites options', (done) => {
+
+        const options = {};
+
+        requestOptions.headers = {
+            'x-arr-ssl': 'information about the SSL server certificate',
+            'disguised-host': 'requested-host',
+            'host': 'internal-host',
+        };
+
+        Helper.createServer(options, routes, (err, server) => {
+
+            server.inject(requestOptions, (response) => {
+
+                expect(err).to.equal(null);
+                expect(response.result.host).to.equal(requestOptions.headers['disguised-host']);
+                expect(response.result.schemes).to.deep.equal(['https']);
+                done();
+            });
+        });
+    });
+
+
     lab.test('adding facade for proxy using route options 1', (done) => {
 
         routes = {


### PR DESCRIPTION
Azure Web Sites does not use `x-forwarded-proto`, while `connection.info.protocol === 'socket'` on their environment due to how iisnode is working.

`getSchema` returning `socket` does not pass the Joi validation and fails hapi-swagger with 500 error on GET /swagger.json.

This fix uses `x-arr-ssl` header from Azure environment as indication that user had send request usign HTTPS.

Request send over HTTP would still result in `socket` schema. And I have no idea on how to solve this without breaking `ws` and `wss` schema detection.