### PR TITLE
Assume that if protocol is socket then request was made using HTTP

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -142,11 +142,24 @@ internals.getSchema = function (request) {
 
     const forwardedProtocol = request.headers['x-forwarded-proto'];
 
-    if (request.headers['x-arr-ssl'] && !forwardedProtocol) {
+    if (forwardedProtocol) {
+        return forwardedProtocol;
+    }
+
+    // Azure Web Sites adds this header when requests was received via HTTPS.
+    if (request.headers['x-arr-ssl']) {
         return 'https';
     }
 
-    return forwardedProtocol || request.connection.info.protocol;
+    const protocol = request.connection.info.protocol;
+
+    // When iisnode is used, connection protocol is `socket`. While IIS
+    // receives request over HTTP and passes it to node via a named pipe.
+    if (protocol === 'socket') {
+        return 'http';
+    }
+
+    return protocol;
 };
 
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,9 +20,21 @@ const helper = module.exports = {};
 */
 helper.createServer = function (swaggerOptions, routes, callback) {
 
+    helper.createServerWithConnection({}, swaggerOptions, routes, callback);
+};
+
+/**
+* creates a Hapi server
+*
+* @param  {Object} swaggerOptions
+* @param  {Object} routes
+* @param  {Function} callback
+*/
+helper.createServerWithConnection = function (connectionOptions, swaggerOptions, routes, callback) {
+
     const server = new Hapi.Server();
 
-    server.connection();
+    server.connection(connectionOptions);
 
     server.register([
         Inert,

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -117,6 +117,35 @@ lab.experiment('proxies', () => {
     });
 
 
+    lab.test('iisnode options', (done) => {
+
+        const connectionOptions = {
+            port: '\\\\.\\pipe\\GUID-expected-here'
+        };
+
+        const options = {};
+
+        requestOptions.headers = {
+            'disguised-host': 'requested-host',
+            'host': 'internal-host',
+        };
+
+        Helper.createServerWithConnection(connectionOptions, options, routes, (err, server) => {
+
+            server.inject(requestOptions, (response) => {
+
+                // Stop because otherwise consecutive test runs would error
+                // with EADDRINUSE.
+                server.stop(done);
+
+                expect(err).to.equal(null);
+                expect(response.result.host).to.equal(requestOptions.headers['disguised-host']);
+                expect(response.result.schemes).to.deep.equal(['http']);
+            });
+        });
+    });
+
+
     lab.test('adding facade for proxy using route options 1', (done) => {
 
         routes = {


### PR DESCRIPTION
In continuation to pull request #231, here is a change which assumes that if protocol is `socket` then request came over `http`.

This is not ideal, but given that `socket` is not considered valid and errors `GET /swagger.json` with 500 error - I propose to give it a try.

I am not planning to use WebSockets on Azure environment for now, so I could not contribute for `ws` and `wss` detection there.