### PR TITLE
Fix: Loading the plugin with a route prefix broke documentation UI

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,15 @@ const appendDataContext = function (plugin, settings) {
             if (request.query.tags) {
                 settings.jsonPath = appendQueryString(settings.jsonPath, 'tags', request.query.tags);
             }
-            response.source.context.hapiSwagger = settings;
+
+            const prefixedSettings = Hoek.clone(settings);
+            if (plugin.realm.modifiers.route.prefix) {
+                ['jsonPath', 'swaggerUIPath'].forEach((setting) => {
+                    prefixedSettings[setting] = plugin.realm.modifiers.route.prefix + prefixedSettings[setting];
+                });
+            }
+
+            response.source.context.hapiSwagger = prefixedSettings;
         }
         return reply.continue();
     });

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -217,6 +217,42 @@ lab.experiment('plugin', () => {
         });
     });
 
+    lab.test('should take the plugin route prefix into account when rendering the UI', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register([
+            Inert,
+            Vision,
+            {
+                register: HapiSwagger,
+                routes: {
+                    prefix: '/implicitPrefix'
+                },
+                options: {}
+            }
+        ], (err) => {
+
+            expect(err).to.not.exist();
+
+            server.route(routes);
+            server.start(function (err) {
+
+                expect(err).to.not.exist();
+                server.inject({ method: 'GET', url: '/implicitPrefix/documentation' }, function (response) {
+
+                    expect(response.statusCode).to.equal(200);
+                    const htmlContent = response.result;
+                    expect(htmlContent).to.contain([
+                        '/implicitPrefix/swaggerui/swagger-ui.js',
+                        '/implicitPrefix/swagger.json'
+                    ]);
+
+                    done();
+                });
+            });
+        });
+    });
 
     lab.test('payloadType = form global', (done) => {
 


### PR DESCRIPTION
Loading the plugin with a route prefix (that might be inherited from a parent plugin) broke all the resource paths within the documentation UI:

- The HTML was rendered without taking the prefix into account
- All route declarations are automatically prefixed

=> The browser can’t load any of the UI resources