### PR TITLE
Separate ports

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -60,10 +60,11 @@ builder.getSwaggerJSON = function (settings, request, callback) {
 
     // remove items that cannot be changed by user
     delete settings.swagger;
+    const connection = settings.connectionToDocument || request.connection;
 
     // collect root information
     builder.default.host = internals.getHost(request);
-    builder.default.schemes = [internals.getSchema(request)];
+    builder.default.schemes = [internals.getSchema(request, connection)];
 
     settings = Hoek.applyToDefaults(builder.default, settings);
     let out = internals.removeNoneSchemaOptions(settings);
@@ -72,7 +73,7 @@ builder.getSwaggerJSON = function (settings, request, callback) {
     out.info = Info.build(settings);
     out.tags = Tags.build(settings);
 
-    let routes = request.connection.table();
+    let routes = connection.table();
 
     routes = Filter.byTags(['api'], routes);
     Sort.paths(settings.sortPaths, routes);
@@ -138,7 +139,7 @@ internals.getHost = function (request) {
  * @param  {Object} request
  * @return {String}
  */
-internals.getSchema = function (request) {
+internals.getSchema = function (request, connection) {
 
     const forwardedProtocol = request.headers['x-forwarded-proto'];
 
@@ -151,7 +152,7 @@ internals.getSchema = function (request) {
         return 'https';
     }
 
-    const protocol = request.connection.info.protocol;
+    const protocol = connection.info.protocol;
 
     // When iisnode is used, connection protocol is `socket`. While IIS
     // receives request over HTTP and passes it to node via a named pipe.
@@ -189,7 +190,8 @@ internals.removeNoneSchemaOptions = function (options) {
         'derefJSONSchema',
         'validatorUrl',
         'jsonEditor',
-        'acceptToProduce'
+        'acceptToProduce',
+        'connectionToDocument'
     ].forEach( (element) => {
 
         delete out[element];

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -60,7 +60,11 @@ builder.getSwaggerJSON = function (settings, request, callback) {
 
     // remove items that cannot be changed by user
     delete settings.swagger;
-    const connection = settings.connectionToDocument || request.connection;
+    let connection = request.connection;
+    if (settings.connectionLabels) {
+      // @TODO: verify that only one connection is matched by connectionLabels during registration
+      connection = request.server.select(settings.connectionLabels).connections[0];
+    }
 
     // collect root information
     builder.default.host = internals.getHost(request);
@@ -191,7 +195,7 @@ internals.removeNoneSchemaOptions = function (options) {
         'validatorUrl',
         'jsonEditor',
         'acceptToProduce',
-        'connectionToDocument'
+        'connectionLabels'
     ].forEach( (element) => {
 
         delete out[element];

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,8 @@ const schema = Joi.object({
     addXProperties: Joi.boolean(),
     derefJSONSchema: Joi.boolean(),
     validatorUrl: Joi.string().allow( null ),
-    acceptToProduce: Joi.boolean()
+    acceptToProduce: Joi.boolean(),
+    connectionToDocument: Joi.object().allow(null)
 }).unknown();
 
 
@@ -49,7 +50,8 @@ const defaults = {
     'addXProperties': false,
     'derefJSONSchema': false,
     'validatorUrl': '//online.swagger.io/validator',
-    'acceptToProduce': true
+    'acceptToProduce': true,
+    'connectionToDocument': null
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ const schema = Joi.object({
     derefJSONSchema: Joi.boolean(),
     validatorUrl: Joi.string().allow( null ),
     acceptToProduce: Joi.boolean(),
-    connectionToDocument: Joi.object().allow(null)
+    connectionLabels: Joi.array().items(Joi.string()).single().allow(null)
 }).unknown();
 
 

--- a/test/document-other-connection-test.js
+++ b/test/document-other-connection-test.js
@@ -1,0 +1,93 @@
+'use strict';
+const Code = require('code');
+const Hapi = require('hapi');
+const Hoek = require('hoek');
+const Inert = require('inert');
+const Lab = require('lab');
+const Vision = require('vision');
+const HapiSwagger = require('../lib/index.js');
+
+const expect = Code.expect;
+const lab = exports.lab = Lab.script();
+
+
+
+lab.experiment('serve on one connection, document another', () => {
+
+    const server = new Hapi.Server();
+
+    lab.before(function (done) {
+
+        server.connection({ host: 'localhost', port: 3000, labels: 'api' });
+        server.connection({ host: 'localhost', port: 3001, labels: 'docs' });
+
+        let testPlugin = function (plugin, options, next) {
+
+            plugin.route({
+                method: 'GET',
+                path: '/plugin1',
+                config: {
+                    handler: function (request, reply) {
+
+                        reply('Hi from plugin 1');
+                    },
+                    description: 'plugin1',
+                    tags: ['api']
+                }
+            });
+            next();
+        };
+        testPlugin.attributes = { name: 'plugin1' };
+
+
+        let swaggerOptions = {
+            schemes: ['http'],
+            info: {
+                'title': 'Test API Documentation',
+                'description': 'This is a sample example of API documentation.',
+                'version': '1.0.0',
+                'termsOfService': 'https://github.com/glennjones/hapi-swagger/',
+                'contact': {
+                    'email': 'glennjonesnet@gmail.com'
+                },
+                'license': {
+                    'name': 'MIT',
+                    'url': 'https://raw.githubusercontent.com/glennjones/hapi-swagger/master/license.txt'
+                }
+            },
+            connectionToDocument: server.select(['api']),
+            host: 'localhost:3000'
+        };
+
+        server.register([
+            Inert,
+            Vision,
+            {
+              register: testPlugin,
+              select: ['api']
+            },
+            {
+              register: HapiSwagger,
+              options: swaggerOptions,
+              select: ['docs']
+            }
+        ]);
+
+        server.start(() => { done(); });
+
+    });
+
+
+
+
+    lab.test('server connection', (done) => {
+
+        const connection = server.select('docs');
+        connection.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+            expect(response.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Firstly, thanks for maintaining this repo! I've used it in several projects, and it is amazing.

At present, I would like this PR to start a conversation about a feature that is very important to me and my team: Serving documentation on one connection for an API that is on a separate connection. This was brought up at least once before in #187 

We are in a similar position to @bboysathish: Our API is served on one port, which is exposed to the public via a load balancer, and our docs are exposed on different ports that is not exposed to the public web. 

I've made some quick changes that will for a plugin option `connectionLabels`. This options will specify which connection to generate the swagger.json from, regardless of which connection is handling the request currently. Would you mind taking a look and letting me know what you think? It is just a starting point, but I want your feedback before investing more time.

Also, the interactive features of swaggerui will still not work, since the the host/port/protocol are all based on the request to `docs/swagger.json`. To solve this, we could also offer a way to override the host/port/protocol with static values via the plugin options, or with the `connection.info` data of the connection matched by `options.connectionLabels`. 