### PR TITLE
Fix: other types than `any` (eg. `binary`) can be file uploads too

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -188,7 +188,7 @@ properties.parseProperty = function (name, joiObj, definitionCollection, altDefi
     }
 
     // convert property to file upload, if indicated by meta property
-    if (Utilities.hasJoiMeta(joiObj) && Utilities.getJoiMetaProperty(joiObj, 'swaggerType') === 'file') {
+    if (Utilities.getJoiMetaProperty(joiObj, 'swaggerType') === 'file') {
         property.type = 'file';
         property.in = 'formData';
     }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -187,12 +187,11 @@ properties.parseProperty = function (name, joiObj, definitionCollection, altDefi
         property = internals.parseAlternatives(property, joiObj, name, definitionCollection, altDefinitionCollection, type);
     }
 
-
-    // add file upload properties
-    if (joiType === 'any' && Utilities.hasJoiMeta(joiObj)) {
-        property = internals.parseAny(property, joiObj);
+    // convert property to file upload, if indicated by meta property
+    if (Utilities.hasJoiMeta(joiObj) && Utilities.getJoiMetaProperty(joiObj, 'swaggerType') === 'file') {
+        property.type = 'file';
+        property.in = 'formData';
     }
-
 
     return Utilities.deleteEmptyProperties(property);
 };
@@ -459,23 +458,6 @@ internals.getName = function (joiObj) {
         return Hoek.reach(joiObj, '_settings.language.label');
     }
     return null;
-};
-
-
-/**
- * parse any property
- *
- * @param  {Object} property
- * @param  {Object} joiObj
- * @return {Object}
- */
-internals.parseAny = function (property, joiObj) {
-
-    if (Utilities.getJoiMetaProperty(joiObj, 'swaggerType') === 'file') {
-        property.type = 'file';
-        property.in = 'formData';
-    }
-    return property;
 };
 
 

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -63,6 +63,33 @@ lab.experiment('file', () => {
         });
     });
 
+    lab.test('upload with binary file type', (done) => {
+        routes.config.validate.payload.file = Joi.binary().meta({ swaggerType: 'file' }).required();
+
+        Helper.createServer({}, routes, (err, server) => {
+
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                //console.log(JSON.stringify(response.result.paths['/test/'].post.parameters));
+                expect(err).to.equal(null);
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.paths['/test/'].post.parameters).to.deep.equal([
+                    {
+                        'type': 'file',
+                        'format': 'binary',
+                        'required': true,
+                        'x-meta': {
+                            'swaggerType': 'file'
+                        },
+                        'name': 'file',
+                        'in': 'formData'
+                    }
+                ]);
+                done();
+            });
+        });
+    });
+
 
 
     lab.test('file type not fired on other meta properties', (done) => {


### PR DESCRIPTION
hapi-swagger currently demands that file upload fields are specified as `joi.any()` but if you want the file to be submitted to the route handler as a buffer, `joi.binary()` is required (afaik). An example:

```JavaScript:
…
validate: {
	payload: {
		someFormField: joi.string().required(),
		anotherFormField: joi.string().required(),
		theFile: joi.binary().required().meta({swaggerType: 'file'})
	}
}
…
```

This PR relaxes hapi-swagger’s property parsing to allow the `.meta({swaggerType: 'file'})` annotation on _any field_  not just `any()` fields 😉.