### PR TITLE
use weakMap to keep definitions from duplicating

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -8,6 +8,8 @@ const definitions = module.exports = {};
 const internals = {};
 
 
+const defCache = new WeakMap();
+
 /**
  * append a new definition object from a joi object
  *
@@ -21,14 +23,23 @@ const internals = {};
 definitions.appendJoi = function (definitionName, joiObj, definitionCollection, altDefinitionCollection, altName, isAlt) {
 
     let currentCollection = (isAlt) ? altDefinitionCollection : definitionCollection;
+    if(!defCache.has(currentCollection)){
+        defCache.set(currentCollection,new WeakMap())
+    }
+    const joiCache = defCache.get(currentCollection);
 
     // covert JOI object into internal object
     let newDefinition;
-    if (Array.isArray(joiObj)) {
+    if(joiCache.has(joiObj)){
+        newDefinition = joiCache.get(joiObj)
+    }
+    else if (Array.isArray(joiObj)) {
         let parameterArray = Properties.toParameters(joiObj, definitionCollection, altDefinitionCollection, null, isAlt);
         newDefinition = internals.wrapParameters(parameterArray);
+        joiCache.set(joiObj,newDefinition);
     } else {
         newDefinition = Properties.parseProperty(definitionName || altName, joiObj, definitionCollection, altDefinitionCollection, isAlt);
+        joiCache.set(joiObj,newDefinition);
     }
 
     return internals.appendFormatted(definitionName, internals.formatProperty(newDefinition), currentCollection, altName);


### PR DESCRIPTION
quickly made something

you will see 3 files here  https://gist.github.com/catalint/68943916badc2cbd62c6030434159005 a before , after , and app to test away

the before has some extra model definitions that get removed after using the cache

there still is an extra model definition there, but that's another issue to solve , not related to this

fixes #251 and #250 