### PR TITLE
handle path rewrites

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ const schema = Joi.object({
     jsonPath: Joi.string(),
     documentationPath: Joi.string(),
     swaggerUIPath: Joi.string(),
+    useDefaultPathsInRoutes: Joi.boolean(),
     auth: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()),
     pathPrefixSize: Joi.number().integer().positive(),
     payloadType: Joi.string().valid(['form', 'json']),
@@ -38,6 +39,7 @@ const defaults = {
     'documentationPath': '/documentation',
     'swaggerUIPath': '/swaggerui/',
     'auth': false,
+    'useDefaultPathsInRoutes': false,
     'pathPrefixSize': 1,
     'payloadType': 'json',
     'enableDocumentation': true,
@@ -67,11 +69,12 @@ exports.register = function (plugin, options, next) {
     let settings = Hoek.applyToDefaults(defaults, options);
     const publicDirPath = __dirname + Path.sep + '..' + Path.sep + 'public';
     const swaggerDirPath = publicDirPath + Path.sep + 'swaggerui';
+    let jsonPath = (settings.useDefaultPathsInRoutes) ? defaults.jsonPath : settings.jsonPath;
 
     // add routing swagger json
     plugin.route([{
         method: 'GET',
-        path: settings.jsonPath,
+        path: jsonPath,
         config: {
             auth: settings.auth,
             handler: (request, reply) => {
@@ -95,6 +98,7 @@ exports.register = function (plugin, options, next) {
         // make sure we have other plug-in dependencies
         plugin.dependency(['inert', 'vision'], (pluginWithDependencies, nextWithDependencies) => {
 
+            let swaggerUIPath = (settings.useDefaultPathsInRoutes) ? defaults.swaggerUIPath : settings.swaggerUIPath;
             // add routing for swaggerui static assets /swaggerui/
             pluginWithDependencies.views({
                 engines: {
@@ -117,7 +121,7 @@ exports.register = function (plugin, options, next) {
                 }
             },{
                 method: 'GET',
-                path: settings.swaggerUIPath + '{path*}',
+                path: swaggerUIPath + '{path*}',
                 config: {
                     auth: settings.auth
                 },
@@ -130,7 +134,7 @@ exports.register = function (plugin, options, next) {
                 }
             },{
                 method: 'GET',
-                path: settings.swaggerUIPath + 'extend.js',
+                path: swaggerUIPath + 'extend.js',
                 config: {
                     auth: settings.auth
                 },
@@ -138,7 +142,7 @@ exports.register = function (plugin, options, next) {
                     file: publicDirPath + Path.sep + 'extend.js'
                 }
             }]);
-
+            delete settings.useDefaultPathsInRoutes;
             appendDataContext(pluginWithDependencies, settings);
 
             nextWithDependencies();


### PR DESCRIPTION
I have a proxy (seaport) in front of my hapi server. It turns

http://localhost:5050/something@1.0.0/documentation 

a proxy call to my hapi server running on a different port, eg 605036 which has no idea it is behind a proxy. 

When I load up the url http://localhost:5050/something@1.0.0/documentation, I have to change 

    swagger_info.swaggerUIPath = '/something@1.0.0/swaggerui/'
    swagger_info.jsonPath =  '/something@1.0.0/swagger.json'

for the ui to request the assets the ui needs. But the problem is changing these also modifies the server routes. 

I have introduced a new config, called 'useDefaultPathsInRoutes'. This by default is false, so the current behaviour is maintained. If it is turned to true, then the server routes are kept to the default values allow the proxy path rewrite condition to be handled correctly
