### PR TITLE
Avoid static 403 errors (inert 4.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,8 @@ The all the files in the URLs below are added by the plugin, but you must server
 <script src='{{hapiSwagger.swaggerUIPath}}extend.js' type='text/javascript'></script>
 
 <!-- Some basic translations -->
-<script src='{{hapiSwagger.swaggerUIPath}}/lang/translator.js' type='text/javascript'></script>
-<script src='{{hapiSwagger.swaggerUIPath}}/lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
+<script src='{{hapiSwagger.swaggerUIPath}}lang/translator.js' type='text/javascript'></script>
+<script src='{{hapiSwagger.swaggerUIPath}}lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
 
 <script type="text/javascript">
 

--- a/bin/custom.html
+++ b/bin/custom.html
@@ -25,8 +25,8 @@
 
 
     <!-- Some basic translations -->
-    <script src='{{hapiSwagger.swaggerUIPath}}/lang/translator.js' type='text/javascript'></script>
-    <script src='{{hapiSwagger.swaggerUIPath}}/lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
+    <script src='{{hapiSwagger.swaggerUIPath}}lang/translator.js' type='text/javascript'></script>
+    <script src='{{hapiSwagger.swaggerUIPath}}lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
 
 <script type="text/javascript">
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,8 +67,8 @@ const defaults = {
 exports.register = function (plugin, options, next) {
 
     let settings = Hoek.applyToDefaults(defaults, options);
-    const publicDirPath = __dirname + Path.sep + '..' + Path.sep + 'public';
-    const swaggerDirPath = publicDirPath + Path.sep + 'swaggerui';
+    const publicDirPath = Path.resolve(__dirname, '..', 'public');
+    const swaggerDirPath = Path.join(publicDirPath, 'swaggerui');
 
 
     // add server method for caching
@@ -170,10 +170,13 @@ exports.register = function (plugin, options, next) {
                 method: 'GET',
                 path: settings.swaggerUIPath + 'extend.js',
                 config: {
-                    auth: settings.auth
+                    auth: settings.auth,
+                    files: {
+                        relativeTo: publicDirPath
+                    }
                 },
                 handler: {
-                    file: publicDirPath + Path.sep + 'extend.js'
+                    file: 'extend.js'
                 }
             }]);
 

--- a/public/swaggerui/index.html
+++ b/public/swaggerui/index.html
@@ -28,8 +28,8 @@
 
 
     <!-- Some basic translations -->
-    <script src='{{hapiSwagger.swaggerUIPath}}/lang/translator.js' type='text/javascript'></script>
-    <script src='{{hapiSwagger.swaggerUIPath}}/lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
+    <script src='{{hapiSwagger.swaggerUIPath}}lang/translator.js' type='text/javascript'></script>
+    <script src='{{hapiSwagger.swaggerUIPath}}lang/{{hapiSwagger.lang}}.js' type='text/javascript'></script>
 
 <script type="text/javascript">
 

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -160,6 +160,18 @@ lab.experiment('plugin', () => {
     });
 
 
+    lab.test('swaggerUIPath + extend.js remapping', (done) => {
+        Helper.createServer({}, routes, (err, server) => {
+
+            server.inject({ method: 'GET', url: '/swaggerui/extend.js' }, function (response) {
+
+                expect(response.statusCode).to.equal(200);
+                done();
+            });
+        });
+    });
+
+
     let swaggerOptions = {
         'jsonPath': '/test.json',
         'documentationPath': '/testdoc',


### PR DESCRIPTION
[inert](https://github.com/hapijs/inert) was bumped to 4.x in the latest hapi release, and thanks to a wasted afternoon debugging without a `CHANGELOG.md` describing what exactly was breaking about `inert` 4.x, I tracked it down to the [new `confine` config option](https://github.com/hapijs/inert/pull/47).

Long story short, the doubled `/` in the request for the lang JS is now a `403 Forbidden`, and the route config `files.relativeTo` needs to be provided for the `extend.js` route (because the default `relativeTo` is whatever the server uses, which in my case was excluding `node_modules`). Otherwise, `extend.js` also returns a `403 Forbidden` when consumers have upgraded their `inert` dependency.

Thanks for all your work on this plugin, we really appreciate it.