### PR TITLE
Make sure plugin is not initialized twice, e.g. in case of server restart

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ exports.register = function (plugin, options, next) {
     let settings = Hoek.applyToDefaults(defaults, options);
     const publicDirPath = __dirname + Path.sep + '..' + Path.sep + 'public';
     const swaggerDirPath = publicDirPath + Path.sep + 'swaggerui';
+    let isInitialized = false; // boolean flag to indicate if plugin is already initialized
 
 
     // add server method for caching
@@ -133,6 +134,12 @@ exports.register = function (plugin, options, next) {
         // make sure we have other plug-in dependencies
         plugin.dependency(['inert', 'vision'], (pluginWithDependencies, nextWithDependencies) => {
 
+            // check if plugin is already initialized
+            if (isInitialized === true) {
+                nextWithDependencies();
+                return; // exit
+            }
+
             // add routing for swaggerui static assets /swaggerui/
             pluginWithDependencies.views({
                 engines: {
@@ -192,6 +199,7 @@ exports.register = function (plugin, options, next) {
             }
 
             appendDataContext(pluginWithDependencies, settings);
+            isInitialized = true; // flag plugin as initialized
 
             nextWithDependencies();
 


### PR DESCRIPTION
hapi-swagger throws an error (i.e. `Cannot set views manager more than once`) when restarting the hapi server in the same process (see example below).

```javascript
const server = new Hapi.Server();
server.register([
  inert,
  vision,
  {
    register: HapiSwagger,
    options: {
      enableDocumentation: true,
      // other options
    }
  }
]).then(() => {
  return server.start();
}).then(() => {
  return server.stop();
}).then(() => {
  return server.start();
}).catch((err) => {
  console.error(err); // outputs "Cannot set views manager more than once"
});
```

This is not as extreme use case as you might think. I am starting and stopping the hapi server multiple times during integration tests.

In any case, this functionality is supported by hapi, so I figured hapi-swagger should support it as well.

Cheers,