### PR TITLE
Request host connection port

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -67,18 +67,16 @@ builder.getSwaggerJSON = function (settings, request, callback) {
     // remove items that cannot be changed by user
     delete settings.swagger;
     let connection = request.connection;
-    let useRequestHost = true;
 
     if (settings.connectionLabel) {
         connection = request.server.select(settings.connectionLabel).connections[0];
-        useRequestHost = false;
         if (request.server.select(settings.connectionLabel).connections.length === 1) {
             request.server.log(['error'], 'connectionLabel should only define one connection to document');
         }
     }
 
     // collect root information
-    builder.default.host = internals.getHost(request, connection, useRequestHost);
+    builder.default.host = internals.getHost(request, connection);
     builder.default.schemes = [internals.getSchema(request, connection)];
 
     settings = Hoek.applyToDefaults(builder.default, settings);
@@ -144,21 +142,16 @@ builder.dereference = function (schema, callback) {
  *
  * @param  {Object} request
  * @param  {Object} connection
- * @param  {Object} useRequestHost
  * @return {String}
  */
-internals.getHost = function (request, connection, useRequestHost) {
+internals.getHost = function (request, connection) {
 
-    let host = connection.info.host;
-    /* $lab:coverage:off$ */
-    if (connection.info.port) {
-        host += ':' + connection.info.port;
-    }
-    /* $lab:coverage:on$ */
-    if (useRequestHost === true){
-        host = request.headers.host;
-    }
-    return request.headers['x-forwarded-host'] || request.headers['disguised-host'] || host;
+    const matches = request.headers.host.match(/^[^:]*/);
+    let host = matches[0];
+    const port = connection.info.port;
+    // Use the request host with the connection's port
+    const hostname =  `${host}:${port}`;
+    return request.headers['x-forwarded-host'] || request.headers['disguised-host'] || hostname;
 };
 
 

--- a/test/document-other-connection-test.js
+++ b/test/document-other-connection-test.js
@@ -84,6 +84,7 @@ lab.experiment('document another connection', () => {
 
             //console.log(JSON.stringify(response.result.paths['/plugin1']))
             expect(response.statusCode).to.equal(200);
+            expect(response.result.host).to.equal('localhost:3000');
             expect(response.result.paths['/plugin1']).to.deep.equal({
                 'get': {
                     'tags': [


### PR DESCRIPTION
# Background

When serving the swagger docs on one connection, and the API on another, the sandbox functionality does not work. This is because `hapi-swagger` is setting the hostname and port to match that of the connection which hosts the API, but most connections are not aware of the actual hostname on which they are reachable (that is handled by external load balancers, proxies, etc...). For instance, when running locally, I can send requests to `localhost:8080`, but the hapi connection on that port thinks that its hostname is `L-SB8V2RBG8W-M.local`. 

# Solution

We know that this server is reachable by the same hostname used to get to the docs in the first place: only the port is different between the docs connection and the API connection. So, we should always use the `request` hostname and the `connection` port. 

# Discussion
This does not fix more complex scenarios in which a proxy is involved which sets `x-forwarded-host`. 