### PR TITLE
Make suppressionVersionFromBasePath work when the basePath is /

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -58,19 +58,20 @@ group.getNameByPath = function (pathPrefixSize, basePath, path, suppressVersionF
             break;
         }
     }
+
     let name = pathHead.join('/');
 
     if (basePath !== '/' && Utilities.startsWith('/' + name, basePath)) {
-        
         name = ('/' + name).replace(basePath, '');
-        
-        if (suppressVersionFromBasePath) {
-             name = name.replace(/v([0-9]+)\//, '');
-        }
-        
-        if (Utilities.startsWith(name, '/')) {
-            name = name.replace('/', '');
-        }
     }
+    
+    if (suppressVersionFromBasePath) {
+         name = name.replace(/v([0-9]+)\//, '');
+    }
+
+    if (Utilities.startsWith(name, '/')) {
+        name = name.replace('/', '');
+    }
+
     return name;
 };

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -368,15 +368,15 @@ internals.cleanPathParameters = function (path) {
  * @return {String}
  */
 internals.removeBasePath = function (path, basePath, suppressVersionFromBasePath) {
-    
+
     if (basePath !== '/' && Utilities.startsWith(path, basePath)) {
         path = path.replace(basePath, '');
-        
-        if (suppressVersionFromBasePath) {
-            path = path.replace(/\/v([0-9]+)?/, '');
-        }        
     }
-    
+
+    if (suppressVersionFromBasePath) {
+        path = path.replace(/\/v([0-9]+)?/, '');
+    }
+
     return path;
 };
 

--- a/test/group-test.js
+++ b/test/group-test.js
@@ -8,7 +8,6 @@ const expect = Code.expect;
 const lab = exports.lab = Lab.script();
 
 
-
 lab.experiment('group', () => {
 
     const routes = [{
@@ -41,10 +40,79 @@ lab.experiment('group', () => {
         }
     }];
 
+    const routesWithVersionInPath = [{
+        method: 'GET',
+        path: '/v1/actors',
+        handler: Helper.defaultHandler,
+        config: {
+            tags: ['api']
+        }
+    }, {
+        method: 'GET',
+        path: '/v1/movies',
+        handler: Helper.defaultHandler,
+        config: {
+            tags: ['api']
+        }
+    }, {
+        method: 'GET',
+        path: '/v1/movies/movie',
+        handler: Helper.defaultHandler,
+        config: {
+            tags: ['api']
+        }
+    }, {
+        method: 'GET',
+        path: '/v1/movies/movie/actor',
+        handler: Helper.defaultHandler,
+        config: {
+            tags: ['api']
+        }
+    }];
 
     lab.test('test groups tagging of paths', (done) => {
 
         Helper.createServer({}, routes, (err, server) => {
+
+            expect(err).to.equal(null);
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                //console.log(JSON.stringify(response.result.paths));
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.paths['/actors'].get.tags[0]).to.equal('actors');
+                expect(response.result.paths['/movies'].get.tags[0]).to.equal('movies');
+                expect(response.result.paths['/movies/movie'].get.tags[0]).to.equal('movies');
+                expect(response.result.paths['/movies/movie/actor'].get.tags[0]).to.equal('movies');
+                done();
+            });
+
+        });
+    });
+
+
+    lab.test('test groups tagging of paths having basePath', (done) => {
+
+        Helper.createServer({ basePath: '/api/' }, routes, (err, server) => {
+
+            expect(err).to.equal(null);
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                //console.log(JSON.stringify(response.result.paths));
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.paths['/actors'].get.tags[0]).to.equal('actors');
+                expect(response.result.paths['/movies'].get.tags[0]).to.equal('movies');
+                expect(response.result.paths['/movies/movie'].get.tags[0]).to.equal('movies');
+                expect(response.result.paths['/movies/movie/actor'].get.tags[0]).to.equal('movies');
+                done();
+            });
+
+        });
+    });
+
+
+    lab.test('test groups tagging of paths having suppressing version from base path', (done) => {
+
+        Helper.createServer({ basePath: '/', suppressVersionFromBasePath: true, pathPrefixSize: 2 }, routesWithVersionInPath, (err, server) => {
 
             expect(err).to.equal(null);
             server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {

--- a/test/path-test.js
+++ b/test/path-test.js
@@ -549,7 +549,31 @@ lab.experiment('path', () => {
             });
         });
     });
-    
+
+    lab.test('path, no basePath suppressing version fragment', (done) => {
+
+        let testRoutes = Hoek.clone(routes);
+        testRoutes.path = '/v3/servers';
+        testRoutes.config.validate = {
+            params: {
+                id: Joi.number().integer().required().description('ID of server to delete'),
+                note: Joi.string().description('Note..')
+            }
+        };
+
+        Helper.createServer({ suppressVersionFromBasePath: true }, testRoutes, (err, server) => {
+
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                expect(err).to.equal(null);
+                //console.log(JSON.stringify(response.result));
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.paths['/servers']).to.exist();
+                done();
+            });
+        });
+    });
+
 
     lab.test('route deprecated', (done) => {
 


### PR DESCRIPTION
Also improved test scenarios for _path-test.js_ and added test (_group-test.js_) cases for the new grouping possibilities that _suppressionVersionFromBasePath_ offer.