### PR TITLE
Run lint during `npm test`, with config tweaks & fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,10 @@
 {
     "rules": {
+        "no-console": 0,
         "indent": [
             2,
-            4
+            4,
+            { "SwitchCase": 1 }
         ],
         "quotes": [
             2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
         ]
     },
     "env": {
+        "node": true,
         "es6": true,
         "browser": true
     },

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
-  - "5.0"
-  - "4.0"
-script: "npm run-script test-cov-coveralls"
+  - "6"
+  - "4"
+  - "5"
+after_success:
+  - "npm run test-cov-coveralls"

--- a/bin/document-other-connection.js
+++ b/bin/document-other-connection.js
@@ -78,6 +78,10 @@ server.register([
     }
 ], (err) => {
 
+    if (err) {
+        console.log(err);
+    }
+
     server.start((err) => {
         if (err) {
             console.log(err);

--- a/bin/swagger-client.js
+++ b/bin/swagger-client.js
@@ -52,7 +52,12 @@ server.register([
     {
         register: HapiSwagger,
         options: swaggerOptions
-    }], (err) => {
+    }],
+    (err) => {
+
+        if (err) {
+            console.log(err);
+        }
 
         /*
         Two of the routes below uses `id: 'add'` in the route options. It is used to make the swagger-client path more human

--- a/bin/test-server-connections.js
+++ b/bin/test-server-connections.js
@@ -85,6 +85,10 @@ server.register([
     Vision
 ], (err) => {
 
+    if (err) {
+        console.log(err);
+    }
+
     // interface a - add swagger UI
     server.register([
         plugin1,
@@ -93,6 +97,10 @@ server.register([
             options: swaggerOptionsA
         }], { select: ['a'] }, (err) => {
 
+            if (err) {
+                console.log(err);
+            }
+
             // interface b - add swagger UI
             server.register([
                 plugin2,
@@ -100,6 +108,10 @@ server.register([
                     register: HapiSwagger,
                     options: swaggerOptionsB
                 }], { select: ['b'] }, (err) => {
+
+                    if (err) {
+                        console.log(err);
+                    }
 
                     server.start(() => {
 
@@ -110,4 +122,3 @@ server.register([
 
 
 server.route(Routes);
-

--- a/bin/test-server-custom.js
+++ b/bin/test-server-custom.js
@@ -75,7 +75,12 @@ server.register([
     {
         register: HapiSwagger,
         options: swaggerOptions
-    }], (err) => {
+    }],
+    (err) => {
+
+        if (err) {
+            console.log(err);
+        }
 
         server.route(Routes);
 

--- a/bin/test-server-promise.js
+++ b/bin/test-server-promise.js
@@ -149,7 +149,7 @@ const registerPlugins = function () {
 
 const registerViews = function () {
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
 
         server.views({
             path: 'bin',
@@ -187,7 +187,7 @@ registerBearer()
         server.route(Routes);
         return startServer(server);
     })
-    .then((msg) => {
+    .then(() => {
         console.log('Server running at:', server.info.uri);
         return registerViews(server);
     })
@@ -197,9 +197,3 @@ registerBearer()
     .catch((err) => {
         console.log(err);
     });
-
-
-
-
-
-

--- a/bin/test-server-versions.js
+++ b/bin/test-server-versions.js
@@ -68,7 +68,8 @@ server.register([
     }, {
         register: HapiApiVersion,
         options: versionOptions
-    }], (err) => {
+    }],
+    (err) => {
 
         if (err) {
             throw err;

--- a/bin/test-server.js
+++ b/bin/test-server.js
@@ -111,6 +111,10 @@ let swaggerOptions = {
 // the auth.strategy needs to be registered before it can be used in options for swagger
 server.register([BearerToken], (err) => {
 
+    if (err) {
+        console.log(err);
+    }
+
     server.auth.strategy('bearer', 'bearer-access-token', {
         'accessTokenName': 'access_token',
         'validateFunc': validateBearer
@@ -138,7 +142,12 @@ server.register([
     {
         register: HapiSwagger,
         options: swaggerOptions
-    }], (err) => {
+    }],
+    (err) => {
+
+        if (err) {
+            console.log(err);
+        }
 
         server.route(Routes);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,7 @@ exports.register = function (plugin, options, next) {
                 Joi.assert(settings, schema);
 
                 if (settings.cache) {
+                    /*eslint no-unused-vars: ["error", { "argsIgnorePattern": "report" }]*/
                     plugin.methods.getSwaggerJSON(settings, request, (err, json, cached, report) => {
 
                         /* $lab:coverage:off$ */

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "start": "node ./bin/test-server.js",
-    "test": "lab -a code -t 100",
+    "test": "lab -L -a code -t 100",
     "test-cov-html": "lab -a code  -r html -o coverage.html",
     "test-cov-coveralls": "./node_modules/.bin/lab -r lcov | ./node_modules/.bin/coveralls"
   },

--- a/test/connections-test.js
+++ b/test/connections-test.js
@@ -88,6 +88,8 @@ lab.experiment('connections', () => {
             Vision
         ], function (err) {
 
+            expect(err).to.equal(undefined);
+
             // interface a - add swagger UI
             server.register([
                 plugin1,
@@ -96,6 +98,8 @@ lab.experiment('connections', () => {
                     options: swaggerOptionsA
                 }], { select: ['a'] }, function (err) {
 
+                    expect(err).to.equal(undefined);
+
                     // interface b - add swagger UI
                     server.register([
                         plugin2,
@@ -103,6 +107,8 @@ lab.experiment('connections', () => {
                             register: HapiSwagger,
                             options: swaggerOptionsB
                         }], { select: ['b'] }, function (err) {
+
+                            expect(err).to.equal(undefined);
 
                             server.start(function () {
 

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -43,8 +43,10 @@ lab.experiment('plugin', () => {
                 HapiSwagger
             ], function (err) {
 
+                expect(err).to.equal(undefined);
                 server.start(function (err) {
 
+                    expect(err).to.exist();
                     done();
                 });
             });
@@ -66,8 +68,10 @@ lab.experiment('plugin', () => {
                 HapiSwagger
             ], function (err) {
 
+                expect(err).to.equal(undefined);
                 server.start(function (err) {
 
+                    expect(err).to.exist();
                     done();
                 });
             });
@@ -134,6 +138,7 @@ lab.experiment('plugin', () => {
             HapiSwagger
         ], function (err) {
 
+            expect(err).to.equal(undefined);
             server.start(function (err) {
 
                 expect(err).to.equal(undefined);

--- a/test/plugin-test.js
+++ b/test/plugin-test.js
@@ -83,7 +83,7 @@ lab.experiment('plugin', () => {
     });
 
 
-    lab.test('plug-in register more than once', (done) => {
+    lab.test('plug-in register more than once', () => {
 
         const server = new Hapi.Server();
         server.connection();
@@ -119,10 +119,7 @@ lab.experiment('plugin', () => {
         }).then(() => {
             return startServer();
         }).then((msg) => {
-            Code.expect(msg).to.equal('Started server');
-            done();
-        }).catch((err) => {
-            done(err);
+            expect(msg).to.equal('Started server');
         });
 
     });


### PR DESCRIPTION
I was digging into a different issue, but I found my editor erupting with red underlines and angry status bar messages about lint errors. It turns out that the linting was never being run during `npm test` (the `-L` option passed to `lab`), despite all the config hanging around. It really should be.

I took great pains to minimize the diffs, especially trivial whitespace. Some of the callback indentation errors, for example, could have been fixed with actual reduction of indent, but that's a noisy diff avoided by a simple newline before the arrow callback.

The Travis tweaks allow it to run `npm test` (gaining the new lint validation as well as actually logging stuff) while still publishing the coverage after a successful build.

1a112fe is not exactly related to linting, but was causing the test run to fail due to uncaught exceptions.