### PR TITLE
Fix typo

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -71,7 +71,7 @@ builder.getSwaggerJSON = function (settings, request, callback) {
     if (settings.connectionLabel) {
         connection = request.server.select(settings.connectionLabel).connections[0];
         useRequestHost = false;
-        if (request.server.select(settings.connectionLabel).connections.length === 1) {
+        if (request.server.select(settings.connectionLabel).connections.length !== 1) {
             request.server.log(['error'], 'connectionLabel should only define one connection to document');
         }
     }


### PR DESCRIPTION
Hi

It seems like this error is raised when there is only one connection matching the `connectionLabel` but it sound like it must be raised when there is more or less than one connection ?

Am I wrong ?