### PR TITLE
fix /documentation page.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,7 +170,7 @@ exports.register = function (plugin, options, next) {
                     },
                     handler: (request, reply) => {
 
-                        reply.view('index.html', {});
+                        reply.view('index.html', { hapiSwagger: settings });
                     }
                 }]);
             }


### PR DESCRIPTION
Previously, the /public/swaggerui/index.html template wasn't being passed the context, meaning the default documentation page was broken, as it could not load any static resources. 

This changes now passes the context to index.html so that the correct static resource urls will be formed in index.html