### PR TITLE
Always clearing the `required` field inside of objects in a definition

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -121,8 +121,8 @@ internals.formatProperties = function (parameters) {
                 out.required = [];
             }
             out.required.push(obj.name);
-            delete obj.required;
         }
+        delete obj.required;
 
         out.properties[obj.name] = obj;
         obj = internals.formatProperty(obj);


### PR DESCRIPTION
Previously, required:false was creeping into the JSON output where it
shouldn't. This breaks in strange ways on some parsers.

I apologize, but I'm not quite sure how to add a test for this bug.