### PR TITLE
Add hapi v14 to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "test-cov-coveralls": "./node_modules/.bin/lab -r lcov | ./node_modules/.bin/coveralls"
   },
   "peerDependencies": {
-    "hapi": "^9.0.1 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
+    "hapi": "^9.0.1 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0"
   }
 }


### PR DESCRIPTION
Hapi v14.0.0 has been released 3 days ago, with a little change. (See: https://github.com/hapijs/hapi/issues/3272)
Since we already using Joi v9, It would work without any problems.