### PR TITLE
Modified parseArray to support array of arrays

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -403,7 +403,9 @@ internals.parseArray = function (property, joiObj, name, definitionCollection, a
                 property.items.format = arrayProperty.format;
             }
         } else {
-            property.items = arrayProperty.schema;
+            //if the property inside the array is not a simple type, 
+            // the items element is set to the array property iteself as a schems
+            property.items = arrayProperty;
         }
     }
 


### PR DESCRIPTION
When the items inside an array include a non-simple type, the items is set to the non-simple type as a schema.