### PR TITLE
In support for array of arrays

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -403,7 +403,9 @@ internals.parseArray = function (property, joiObj, name, definitionCollection, a
                 property.items.format = arrayProperty.format;
             }
         } else {
-            property.items = arrayProperty.schema;
+            //if the property inside the array is not a simple type, 
+            // the items element is set to the array property iteself as a schems
+            property.items = arrayProperty;
         }
     }
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -409,7 +409,7 @@ internals.parseArray = function (property, joiObj, name, definitionCollection, a
                 property.items = arrayProperty.schema;
             } else {
                 property.items = arrayProperty;
-          }
+            }
         }
     }
 

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -403,9 +403,13 @@ internals.parseArray = function (property, joiObj, name, definitionCollection, a
                 property.items.format = arrayProperty.format;
             }
         } else {
-            //if the property inside the array is not a simple type, 
-            // the items element is set to the array property iteself as a schems
-            property.items = arrayProperty;
+            // If the property inside the array is not a simple type, and the inner property has no schema, 
+            // then  the items element is set to the array property itself as a schemas 
+            if(arrayProperty.schema) {
+                property.items = arrayProperty.schema;
+            } else {
+                property.items = arrayProperty;
+          }
         }
     }
 


### PR DESCRIPTION
If the property inside the array is not a simple type, and the inner property has no schema, then  the items element is set to the array property itself as a schemas 