### PR TITLE
maximum->maxLength, minimum->minLength

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -316,8 +316,8 @@ internals.properties.prototype.parseString = function (property, joiObj) {
 internals.properties.prototype.parseNumber = function (property, joiObj) {
 
     const describe = joiObj.describe();
-    property.minimum = internals.getArgByName(describe.rules, 'min');
-    property.maximum = internals.getArgByName(describe.rules, 'max');
+    property.minLength = internals.getArgByName(describe.rules, 'min');
+    property.maxLength = internals.getArgByName(describe.rules, 'max');
     if (internals.hasPropertyByName(describe.rules, 'integer')) {
         property.type = 'integer';
     }

--- a/test/propertie-test.js
+++ b/test/propertie-test.js
@@ -158,8 +158,8 @@ lab.experiment('property - ', () => {
 
         // mapped direct to openapi
         expect(propertiesNoAlt.parseProperty('x', Joi.number().integer())).to.equal({ 'type': 'integer' });
-        expect(propertiesNoAlt.parseProperty('x', Joi.number().min(5))).to.equal({ 'type': 'number', 'minimum': 5 });
-        expect(propertiesNoAlt.parseProperty('x', Joi.number().max(10))).to.equal({ 'type': 'number', 'maximum': 10 });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().min(5))).to.equal({ 'type': 'number', 'minLength': 5 });
+        expect(propertiesNoAlt.parseProperty('x', Joi.number().max(10))).to.equal({ 'type': 'number', 'maxLength': 10 });
 
         // x-* mappings
         expect(propertiesAlt.parseProperty('x', Joi.number().greater(10))).to.equal({ 'type': 'number', 'x-constraint': { 'greater': 10 } });


### PR DESCRIPTION
according to http://swagger.io/specification/ for strings, maxLength and minLength should be used to describe the max and minimum number of characters within strings.