### PR TITLE
Do note remove name if not generic 'Modelx' name

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -33,7 +33,8 @@ internals.definitions.prototype.append = function (definitionName, definition, c
     //}
 
     // remove unneeded properties
-    delete definition.name;
+    if(typeof definition.name === 'string' && definition.name.startsWith('Model'))
+        delete definition.name;
 
     // find existing definition by this definitionName
     let foundDefinition = currentCollection[definitionName];
@@ -104,7 +105,8 @@ internals.formatProperty = function (obj) {
     obj = Utilities.deleteEmptyProperties(obj);
 
     // remove unneeded properties
-    delete obj.name;
+    if(typeof obj.name === 'string' && obj.name.startsWith('Model'))
+        delete obj.name;
 
     return obj;
 };


### PR DESCRIPTION
This prevent merging similar definition which have different label as referred in #366 