### PR TITLE
Windows: All tests pass with team whitespace rules (#381)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.md]
+indent_style = space
+indent_size = 4
+
+[*.{js,json}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[package.json]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.js eol=lf
+*.json eol=lf
+*.sh eol=lf
+*.md eol=lf
+*.conf eol=lf

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,7 +190,7 @@ exports.register = function (plugin, options, next) {
             if (settings.debug === true) {
                 pluginWithDependencies.route([{
                     method: 'GET',
-                    path: settings.documentationPath + Path.sep + 'debug',
+                    path: Path.join(settings.documentationPath, Path.sep, 'debug').split(Path.sep).join('/'),
                     config: {
                         auth: settings.auth
                     },


### PR DESCRIPTION
* Added editorconfig to force IDE to follow team standard whitespace
* Added gitattributes to force Git to use LF not Windows line endings
* Update path so Windows (and hopefully POSIX) tests all pass