### PR TITLE
Support configuration for routes that are defined by the hapi-swagger plugin

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -223,6 +223,7 @@ internals.removeNoneSchemaOptions = function (options) {
         'documentationPage',
         'jsonPath',
         'auth',
+        'routeConfig',
         'swaggerUIPath',
         'swaggerUI',
         'pathPrefixSize',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -4,7 +4,8 @@ module.exports = {
     'jsonPath': '/swagger.json',
     'documentationPath': '/documentation',
     'swaggerUIPath': '/swaggerui/',
-    'auth': false,
+    'auth': false, // obsolete use routeConfig.auth instead
+    'routeConfig': {},
     'pathPrefixSize': 1,
     'payloadType': 'json',
     'documentationPage': true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ exports.register = function (plugin, options, next) {
     plugin.route([{
         method: 'GET',
         path: settings.jsonPath,
-        config: Object.assign(settings.routeConfig, {
+        config: Object.assign({}, settings.routeConfig, {
             auth: settings.auth,
             handler: (request, reply) => {
 
@@ -153,7 +153,7 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.documentationPath,
-                    config: Object.assign(settings.routeConfig, {
+                    config: Object.assign({}, settings.routeConfig, {
                         auth: settings.auth
                     }),
                     handler: (request, reply) => {
@@ -168,7 +168,7 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.swaggerUIPath + '{path*}',
-                    config: Object.assign(settings.routeConfig, {
+                    config: Object.assign({}, settings.routeConfig, {
                         auth: settings.auth
                     }),
                     handler: {
@@ -181,7 +181,7 @@ exports.register = function (plugin, options, next) {
                 }, {
                     method: 'GET',
                     path: settings.swaggerUIPath + 'extend.js',
-                    config: Object.assign(settings.routeConfig, {
+                    config: Object.assign({}, settings.routeConfig, {
                         auth: settings.auth,
                         files: {
                             relativeTo: publicDirPath
@@ -198,7 +198,7 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.documentationPath + Path.sep + 'debug',
-                    config: Object.assign(settings.routeConfig, {
+                    config: Object.assign({}, settings.routeConfig, {
                         auth: settings.auth
                     }),
                     handler: (request, reply) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,9 @@ const schema = Joi.object({
     documentationPath: Joi.string(),
     swaggerUIPath: Joi.string(),
     auth: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object()),
+    routeConfig: Joi.object({
+        auth: Joi.alternatives().try(Joi.boolean(), Joi.string(), Joi.object())
+    }).unknown(),
     pathPrefixSize: Joi.number().integer().positive(),
     payloadType: Joi.string().valid(['form', 'json']),
     documentationPage: Joi.boolean(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,10 +71,6 @@ exports.register = function (plugin, options, next) {
     };
     settings.log(['info'], 'Started');
 
-    if (settings.auth) {
-        settings.log(['warn'], 'The `auth` option is deprecated. `Use routeConfig.auth` instead');
-    }
-
     // add server method for caching
     if (settings.cache) {
         // set default

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,10 @@ exports.register = function (plugin, options, next) {
     };
     settings.log(['info'], 'Started');
 
+    if (settings.auth) {
+        settings.log(['warn'], 'The `auth` option is deprecated. `Use routeConfig.auth` instead');
+    }
+
     // add server method for caching
     if (settings.cache) {
         // set default
@@ -90,7 +94,7 @@ exports.register = function (plugin, options, next) {
     plugin.route([{
         method: 'GET',
         path: settings.jsonPath,
-        config: {
+        config: Object.assign(settings.routeConfig, {
             auth: settings.auth,
             handler: (request, reply) => {
 
@@ -121,7 +125,7 @@ exports.register = function (plugin, options, next) {
             plugins: {
                 'hapi-swagger': false
             }
-        }
+        })
     }]);
 
 
@@ -146,9 +150,9 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.documentationPath,
-                    config: {
+                    config: Object.assign(settings.routeConfig, {
                         auth: settings.auth
-                    },
+                    }),
                     handler: (request, reply) => {
 
                         reply.view('index.html', {});
@@ -161,9 +165,9 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.swaggerUIPath + '{path*}',
-                    config: {
+                    config: Object.assign(settings.routeConfig, {
                         auth: settings.auth
-                    },
+                    }),
                     handler: {
                         directory: {
                             path: swaggerDirPath + Path.sep,
@@ -174,12 +178,12 @@ exports.register = function (plugin, options, next) {
                 }, {
                     method: 'GET',
                     path: settings.swaggerUIPath + 'extend.js',
-                    config: {
+                    config: Object.assign(settings.routeConfig, {
                         auth: settings.auth,
                         files: {
                             relativeTo: publicDirPath
                         }
-                    },
+                    }),
                     handler: {
                         file: 'extend.js'
                     }
@@ -191,9 +195,9 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.documentationPath + Path.sep + 'debug',
-                    config: {
+                    config: Object.assign(settings.routeConfig, {
                         auth: settings.auth
-                    },
+                    }),
                     handler: (request, reply) => {
 
                         reply.view('debug.html', {}).type('application/json');

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -179,15 +179,15 @@ internals.paths.prototype.buildRoutes = function (routes) {
     routes.forEach((route) => {
 
         let method = route.method;
+        let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
         let out = {
             'summary': route.description,
-            'operationId': route.id || Utilities.createId(route.method, route.path),
+            'operationId': route.id || Utilities.createId(route.method, path),
             'description': route.notes,
             'parameters': [],
             'consumes': [],
             'produces': []
         };
-        let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
 
         // tags in swagger are used for grouping
         out.tags = route.groups;


### PR DESCRIPTION
Added 'routeConfig' property which can be used as default starting point for anything that has to be changed in the route configuration for routes that are defined by the hapi-swagger plugin. 

The case it covers for instance is if you set globally `cors: false` you can enable it for hapi routes 
by using `routeConfig: {cors: true}`

The `auth` property now also can be defined via routeConfig