### PR TITLE
OperationId. Remove basePath prefix from operationId

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -179,15 +179,15 @@ internals.paths.prototype.buildRoutes = function (routes) {
     routes.forEach((route) => {
 
         let method = route.method;
+        let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
         let out = {
             'summary': route.description,
-            'operationId': route.id || Utilities.createId(route.method, route.path),
+            'operationId': route.id || Utilities.createId(route.method, path),
             'description': route.notes,
             'parameters': [],
             'consumes': [],
             'produces': []
         };
-        let path = internals.removeBasePath(route.path, this.settings.basePath, this.settings.pathReplacements);
 
         // tags in swagger are used for grouping
         out.tags = route.groups;


### PR DESCRIPTION
I've noticed that `operationId` includes whole path including `basePath` that is specified in settings. 

For some cases it might be very inconvenient.

I'm using `swagger-client` and my REST api is prefixed with `/rest/api/v2/`
So the resulting methods look like `client.permissions.getRestApiV2Permissions`
instead I'd like to see `client.permissions.getPermissions`. 

Fortunately enough it was an easy fix. 
 