### PR TITLE
Allow custom options info properties

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -31,7 +31,7 @@ info.schema = Joi.object({
         url: Joi.string().uri()
     }),
     version: Joi.string().required()
-});
+}).pattern(/^x-/, Joi.any());
 
 
 /**

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -24,6 +24,9 @@ JSON (JSON endpoint needed to create UI)
     * `name` (string) A contact name for the API
     * `url` (string) A URL pointing to the contact information. MUST be formatted as a URL
     * `email` (string) A email address of the contact person/organization. MUST be formatted as an email address.
+  * `x-*` (any): any property or object with a key starting with *x-* is included as such in the *info* section
+    of the object return by the JSON endpoint. This allows custom properties to be defined as options and
+    copied as such.
   * `license`
     * `name` (string) The name of the license used for the API
     * `url` (string) The URL to the license used by the API. MUST be formatted as a URL

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -24,12 +24,12 @@ JSON (JSON endpoint needed to create UI)
     * `name` (string) A contact name for the API
     * `url` (string) A URL pointing to the contact information. MUST be formatted as a URL
     * `email` (string) A email address of the contact person/organization. MUST be formatted as an email address.
-  * `x-*` (any): any property or object with a key starting with *x-* is included as such in the *info* section
-    of the object return by the JSON endpoint. This allows custom properties to be defined as options and
-    copied as such.
   * `license`
     * `name` (string) The name of the license used for the API
     * `url` (string) The URL to the license used by the API. MUST be formatted as a URL
+  * `x-*` (any): any property or object with a key starting with *x-* is included as such in the *info* section
+    of the object return by the JSON endpoint. This allows custom properties to be defined as options and
+    copied as such.
 *  `tags`: (array) containing array of [Tag Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tagObject) used to group endpoints in UI. No defaults are provided.
 *  `securityDefinitions:`: (object) Containing [Security Definitions Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject). No defaults are provided.
 *  `payloadType`: (string) How payload parameters are displayed `json` or `form` - default: `json`

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -28,7 +28,7 @@ JSON (JSON endpoint needed to create UI)
     * `name` (string) The name of the license used for the API
     * `url` (string) The URL to the license used by the API. MUST be formatted as a URL
   * `x-*` (any): any property or object with a key starting with *x-* is included as such in the *info* section
-    of the object return by the JSON endpoint. This allows custom properties to be defined as options and
+    of the object returned by the JSON endpoint. This allows custom properties to be defined as options and
     copied as such.
 *  `tags`: (array) containing array of [Tag Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#tagObject) used to group endpoints in UI. No defaults are provided.
 *  `securityDefinitions:`: (object) Containing [Security Definitions Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject). No defaults are provided.

--- a/test/Integration/info-test.js
+++ b/test/Integration/info-test.js
@@ -107,4 +107,27 @@ lab.experiment('info', () => {
         });
     });
 
+    lab.test('info object with custom properties', (done) => {
+
+        const swaggerOptions = {
+            info: {
+                'title': 'test title for lab',
+                'version': '0.0.1',
+                'x-custom': 'custom'
+            }
+        };
+
+        Helper.createServer(swaggerOptions, routes, (err, server) => {
+
+            expect(err).to.equal(null);
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.info).to.equal(swaggerOptions.info);
+                Helper.validate(response, done, expect);
+            });
+        });
+    });
+
+
 });


### PR DESCRIPTION
Any options info property or object with a key starting with *x-* is included as such in the *info* section of the object returned by the JSON endpoint. This allows custom properties to be defined as options and copied as such.

No change to UI page as there isn't necessarily a standard way of displaying such custom properties.

With unit test and proposed updated README

Output of  `npm test`:

```
$ npm test

> hapi-swagger@7.6.0 test D:\GitHub\public\hapi-swagger
> lab -L -t 100



  ..................................................
  ..................................................
  ..................................................
  ..................................

184 tests complete
Test duration: 3388 ms
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```

Thanks