### PR TITLE
Added option to use "label" as the next model name prefix

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -239,6 +239,7 @@ internals.removeNoneSchemaOptions = function (options) {
         'reuseDefinitions',
         'uiCompleteScript',
         'deReference',
+        'dynamicDefinitionPrefix',
         'validatorUrl',
         'jsonEditor',
         'acceptToProduce',

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -239,7 +239,7 @@ internals.removeNoneSchemaOptions = function (options) {
         'reuseDefinitions',
         'uiCompleteScript',
         'deReference',
-        'dynamicDefinitionPrefix',
+        'definitionPrefix',
         'validatorUrl',
         'jsonEditor',
         'acceptToProduce',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -19,7 +19,7 @@ module.exports = {
     'uiCompleteScript': null,
     'xProperties': true,
     'reuseDefinitions': true,
-    'dynamicDefinitionPrefix': 'default',
+    'definitionPrefix': 'default',
     'deReference': false,
     'validatorUrl': '//online.swagger.io/validator',
     'acceptToProduce': true,  // internal, NOT public

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -19,6 +19,7 @@ module.exports = {
     'uiCompleteScript': null,
     'xProperties': true,
     'reuseDefinitions': true,
+    'dynamicDefinitionPrefix': 'default',
     'deReference': false,
     'validatorUrl': '//online.swagger.io/validator',
     'acceptToProduce': true,  // internal, NOT public

--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -4,9 +4,7 @@ const Hash = require('../lib/hash');
 const Utilities = require('../lib/utilities');
 
 
-const internals = {
-    modelPrefixes: {}
-};
+const internals = {};
 
 exports = module.exports = internals.definitions = function (settings) {
 
@@ -82,7 +80,7 @@ internals.append = function (definitionName, definition, currentCollection, forc
     } else {
         // else create a new item using definitionName or next model number
         if (forceDynamicName) {
-            if (settings.dynamicDefinitionPrefix === 'useLabel') {
+            if (settings.definitionPrefix === 'useLabel') {
                 out = internals.nextModelName(definitionName + ' ', currentCollection);
             }
             else {

--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -4,7 +4,9 @@ const Hash = require('../lib/hash');
 const Utilities = require('../lib/utilities');
 
 
-const internals = {};
+const internals = {
+    modelPrefixes: {}
+};
 
 exports = module.exports = internals.definitions = function (settings) {
 
@@ -44,11 +46,11 @@ internals.definitions.prototype.append = function (definitionName, definition, c
             out = definitionName;
         } else {
             // create new definition
-            out = internals.append(null, definition, currentCollection, settings);
+            out = internals.append(definitionName, definition, currentCollection, true, settings);
         }
     } else {
         // create new definition
-        out = internals.append(definitionName, definition, currentCollection, settings);
+        out = internals.append(definitionName, definition, currentCollection, false, settings);
     }
 
     return out;
@@ -64,7 +66,7 @@ internals.definitions.prototype.append = function (definitionName, definition, c
  * @param  {Object} settings
  * @return {String}
  */
-internals.append = function (definitionName, definition, currentCollection, settings) {
+internals.append = function (definitionName, definition, currentCollection, forceDynamicName, settings) {
 
     let out;
     let foundDefinitionName;
@@ -79,7 +81,17 @@ internals.append = function (definitionName, definition, currentCollection, sett
         out = foundDefinitionName;
     } else {
         // else create a new item using definitionName or next model number
-        out = definitionName || internals.nextModelName(currentCollection);
+        if (forceDynamicName) {
+            if (settings.dynamicDefinitionPrefix === 'useLabel') {
+                out = internals.nextModelName(definitionName + ' ', currentCollection);
+            }
+            else {
+                out = internals.nextModelName('Model ', currentCollection);
+            }
+        }
+        else {
+            out = definitionName || internals.nextModelName('Model ', currentCollection);
+        }
         currentCollection[out] = definition;
     }
     return out;
@@ -126,22 +138,22 @@ internals.hash = function (obj) {
 /**
  * creates a new unique model name
  *
+ * @param  {String} nextModelNamePrefix
  * @param  {Object} currentCollection
  * @return {String}
  */
-internals.nextModelName = function (currentCollection) {
-
+internals.nextModelName = function (nextModelNamePrefix, currentCollection) {
     let highest = 0;
     let key;
     for (key in currentCollection) {
-        if (Utilities.startsWith(key, 'Model')) {
-            let num = parseInt(key.replace('Model', ''), 10);
+        if (Utilities.startsWith(key, nextModelNamePrefix)) {
+            let num = parseInt(key.replace(nextModelNamePrefix, ''), 10) || 0;
             if (num && num > highest) {
                 highest = num;
             }
         }
     }
-    return 'Model ' + (highest + 1);
+    return nextModelNamePrefix + (highest + 1);
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const schema = Joi.object({
     uiCompleteScript: Joi.string().allow(null),
     xProperties: Joi.boolean(),
     reuseDefinitions: Joi.boolean(),
-    dynamicDefinitionPrefix: Joi.string(),
+    definitionPrefix: Joi.string(),
     deReference: Joi.boolean(),
     validatorUrl: Joi.string().allow(null),
     acceptToProduce: Joi.boolean(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ const schema = Joi.object({
     uiCompleteScript: Joi.string().allow(null),
     xProperties: Joi.boolean(),
     reuseDefinitions: Joi.boolean(),
+    dynamicDefinitionPrefix: Joi.string(),
     deReference: Joi.boolean(),
     validatorUrl: Joi.string().allow(null),
     acceptToProduce: Joi.boolean(),

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -35,6 +35,7 @@ JSON (JSON endpoint needed to create UI)
 *  `produces`: (array) The mimetypes produced - default: `['application/json']`
 *  `xProperties`: Adds JOI data that cannot be use directly by swagger as metadata - default: `true`,
 *  `reuseDefinitions`: Reuse of definition models to save space - default: `true`,
+*  `definitionPrefix`: Dynamic naming convention. `default` or `useLabel` - default: `default`,
 *  `deReference`: Dereferences JSON output - default: `false`,
 *  `debug`: Validates the JSON ouput against swagger specification - default: `false`,
 

--- a/test/Integration/definitions-test.js
+++ b/test/Integration/definitions-test.js
@@ -190,7 +190,7 @@ lab.experiment('definitions', () => {
         });
     });
 
-    lab.test('dynamicDefinitionPrefix = useLabel', (done) => {
+    lab.test('definitionPrefix = useLabel', (done) => {
 
         // use the label as a prefix for dynamic model names
 
@@ -241,7 +241,7 @@ lab.experiment('definitions', () => {
             }
         }];
 
-        Helper.createServer({ dynamicDefinitionPrefix: 'useLabel' }, tempRoutes, (err, server) => {
+        Helper.createServer({ definitionPrefix: 'useLabel' }, tempRoutes, (err, server) => {
 
             expect(err).to.equal(null);
             server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {

--- a/test/Integration/definitions-test.js
+++ b/test/Integration/definitions-test.js
@@ -190,6 +190,70 @@ lab.experiment('definitions', () => {
         });
     });
 
+    lab.test('dynamicDefinitionPrefix = useLabel', (done) => {
+
+        // use the label as a prefix for dynamic model names
+
+        const tempRoutes = [{
+            method: 'POST',
+            path: '/store1/',
+            config: {
+                handler: Helper.defaultHandler,
+                tags: ['api'],
+                validate: {
+                    payload: Joi.object({
+                        a: Joi.number(),
+                        b: Joi.number(),
+                        operator: Joi.string(),
+                        equals: Joi.number()
+                    }).label('A')
+                }
+            }
+        }, {
+            method: 'POST',
+            path: '/store2/',
+            config: {
+                handler: Helper.defaultHandler,
+                tags: ['api'],
+                validate: {
+                    payload: Joi.object({
+                        c: Joi.number(),
+                        v: Joi.number(),
+                        operator: Joi.string(),
+                        equals: Joi.number()
+                    }).label('A A')
+                }
+            }
+        }, {
+            method: 'POST',
+            path: '/store3/',
+            config: {
+                handler: Helper.defaultHandler,
+                tags: ['api'],
+                validate: {
+                    payload: Joi.object({
+                        c: Joi.number(),
+                        f: Joi.number(),
+                        operator: Joi.string(),
+                        equals: Joi.number()
+                    }).label('A')
+                }
+            }
+        }];
+
+        Helper.createServer({ dynamicDefinitionPrefix: 'useLabel' }, tempRoutes, (err, server) => {
+
+            expect(err).to.equal(null);
+            server.inject({ method: 'GET', url: '/swagger.json' }, function (response) {
+
+                expect(response.statusCode).to.equal(200);
+                expect(response.result.definitions.A).to.exist();
+                expect(response.result.definitions['A A']).to.exist();
+                expect(response.result.definitions['A 1']).to.exist();
+                Helper.validate(response, done, expect);
+            });
+        });
+    });
 
     lab.test('test that optional array is not in swagger output', (done) => {
 

--- a/usageguide.md
+++ b/usageguide.md
@@ -118,7 +118,8 @@ validate: {
 ```
 __NOTE: the plugin reuses "definition models" these describe each JSON object use by an API i.e. a "user". This feature
 was added to reduce the size of the JSON. The reuse of models can cause names to be reused as well. Please switch
-`options.reuseDefinitions` to `false` if you are nameing your JOI objects.__
+`options.reuseDefinitions` to `false` if you are naming your JOI objects. By default objects are named in a "Model #"
+ format. To use the `label`, specify `options.definitionPrefix` as `useLabel`.__
 
 
 


### PR DESCRIPTION
Currently the next model name is always "Model #". However if you have a dynamic model that uses the same label, but with different fields or description, then the numbering can balloon up very quickly.

I've added an option called "definitionPrefix", which when set to "useLabel", will use the label as the numbering base. E.g. If I have a model called "baseErrors", then all my flavours of baseErrors will be "baseErrors 1", "baseErrors 2" etc, which is better to read.