### PR TITLE
Disable dropdown for a property in UI via meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ npm-debug.log
 .DS_Store
 .vscode
 .coveralls.yml
+.idea
 
 test/certs/server.csr

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -111,7 +111,8 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
 
     // add enum
     let describe = joiObj.describe();
-    if (Array.isArray(describe.valids) && describe.valids.length) {
+    const allowDropdown = !property['x-meta'] || !property['x-meta'].disableDropdown;
+    if (allowDropdown && Array.isArray(describe.valids) && describe.valids.length) {
         // fliter out empty values and arrays
         var enums = describe.valids.filter((item) => {
 

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -103,7 +103,6 @@ lab.experiment('property - ', () => {
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b']), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', '']), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', null]), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
-        expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', null]), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp')).default).to.exist();
         //console.log(JSON.stringify(propertiesAlt.parseProperty('x',Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp'))));
 

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -103,8 +103,15 @@ lab.experiment('property - ', () => {
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b']), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', '']), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', null]), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
+        expect(propertiesNoAlt.parseProperty('x', Joi.string().valid(['a', 'b', null]), null, 'body', true, false)).to.equal({ type: 'string', enum: ['a', 'b'] });
         expect(propertiesNoAlt.parseProperty('x', Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp')).default).to.exist();
         //console.log(JSON.stringify(propertiesAlt.parseProperty('x',Joi.date().timestamp().default(() => Date.now(), 'Current Timestamp'))));
+
+        const nonNegativeWithDropdown = propertiesAlt.parseProperty('x', Joi.number().integer().positive().allow(0), null, 'body', true, false);
+        const nonNegativeWithoutDropdown = propertiesAlt.parseProperty('x', Joi.number().integer().positive().allow(0).meta({disableDropdown: true}), null, 'body', true, false);
+
+        expect(nonNegativeWithDropdown).to.include({ enum: [0] });
+        expect(nonNegativeWithoutDropdown).to.not.include({ enum: [0] });
 
         done();
     });


### PR DESCRIPTION
Joi.allow() creates a valid list that results on dropdown in Swagger
docs UI. This is not expected in many cases and here we add
`disableDropdown` meta property for those.

One example that is used in tests is non-negative integers that could
not be edited in swagger UI forms:

    Joi.number().integer().positive().allow(0)

Only by adding `.meta({disableDropdown: true})` one could make this
editable as a form field.

Let me know if there is a better way to achieve this or the PR needs changes.