### PR TITLE
Fix `auth` setting to fully load the swagger UI

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,9 +163,6 @@ exports.register = function (plugin, options, next) {
                 pluginWithDependencies.route([{
                     method: 'GET',
                     path: settings.swaggerUIPath + '{path*}',
-                    config: {
-                        auth: settings.auth
-                    },
                     handler: {
                         directory: {
                             path: swaggerDirPath + Path.sep,
@@ -177,7 +174,6 @@ exports.register = function (plugin, options, next) {
                     method: 'GET',
                     path: settings.swaggerUIPath + 'extend.js',
                     config: {
-                        auth: settings.auth,
                         files: {
                             relativeTo: publicDirPath
                         }

--- a/public/swaggerui/index.html
+++ b/public/swaggerui/index.html
@@ -63,8 +63,11 @@
         validatorUrl: '{{hapiSwagger.validatorUrl}}';
         {{/if}}
 
+		var ACCESS_TOKEN_QUERY_PARAM_NAME = 'access_token';
+		var accessToken = getUrlVars()[ACCESS_TOKEN_QUERY_PARAM_NAME];
+
         window.swaggerUi = new SwaggerUi({
-            url: url,
+			url: url + (accessToken? (url.indexOf('?') < 0? '?' : '&') + ACCESS_TOKEN_QUERY_PARAM_NAME + '=' + accessToken : ''),
             dom_id: "swagger-ui-container",
             supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
             onComplete: function (swaggerApi, swaggerUi) {
@@ -123,6 +126,17 @@
             }
         }
 
+		function getUrlVars() {
+			var vars = [], hash;
+			var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+			for(var i = 0; i < hashes.length; i++)
+			{
+				hash = hashes[i].split('=');
+				vars.push(hash[0]);
+				vars[hash[0]] = hash[1];
+			}
+			return vars;
+		}
 
         $('#input_apiKey').change(addApiKeyAuthorization);
 


### PR DESCRIPTION
There was an issue with loading swagger UI with `auth` specified: in this case the base URL `/documentation` would load, but not any of the dependent resources.

This PR attempts to fix the forementioned issue by:
* Removing `auth` settings from the public resources (css, scripts, libs)
* Adding `access_token` query param to the URL of the `swagger.json` during the initialization of the `SwaggerUI` object
