### PR TITLE
Bug fix: Don't set x-alternatives on property if property is undefined

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -514,7 +514,7 @@ internals.properties.prototype.parseAlternatives = function (property, joiObj, n
         property = this.parseProperty(childName, child, property, parameterType, useDefinitions, false);
 
         // create the alternatives without appending to the definitionCollection
-        if (this.settings.xProperties === true) {
+        if (this.settings.xProperties === true && property !== undefined) {
             let altArray = joiObj._inner.matches
                 .reduce((res, obj) => {
                     obj.then && res.push(obj.then);


### PR DESCRIPTION
Small bug fix: 
`property` can be undefined on line 529 of property.js, because `parseProperty()` on line 514 might return `undefined` (for instance if there is a Joi.forbidden()). Line 529 will then throw a TypeError (trying to set x-alternatives on undefined)