### PR TITLE
Fix missing object and array descriptions in swagger UI

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -146,7 +146,8 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
             if (useDefinitions === true) {
                 let refName = this.definitions.append(name, property, this.getDefinitionCollection(isAlt), this.settings);
                 property = {
-                    '$ref': this.getDefinitionRef(isAlt) + refName
+                    '$ref': this.getDefinitionRef(isAlt) + refName,
+                    'description': property.description
                 };
             }
 
@@ -173,7 +174,8 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
             let refName = this.definitions.append(name, property, this.getDefinitionCollection(isAlt), this.settings);
             property = {
                 '$ref': this.getDefinitionRef(isAlt) + refName,
-                'type': 'array'
+                'type': 'array',
+                'description': property.description
             };
         }
     }

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -913,7 +913,8 @@ lab.experiment('responses', () => {
                             responses: {
                                 '200': {
                                     schema: {
-                                        $ref: '#/definitions/Sum'
+                                        $ref: '#/definitions/Sum',
+                                        description: 'json body for sum'
                                     },
                                     description: 'Success with response.schema'
                                 }
@@ -974,7 +975,8 @@ lab.experiment('responses', () => {
                                 '200': {
                                     description: 'json body for sum',
                                     schema: {
-                                        $ref: '#/definitions/Sum'
+                                        $ref: '#/definitions/Sum',
+                                        description: 'json body for sum'
                                     }
                                 },
                                 '400': {


### PR DESCRIPTION
Swagger UI only shows the "description" fields for properties, not for definitions. Therefore, when referencing an object or array definition, we need to copy their descriptions onto the property. Otherwise they won’t show up in Swagger UI at all.

I’m not happy with this workaround but I don’t know any better solution.

If you merge this PR, could you add it to another 7.x release instead of 8.x? We won’t be able to upgrade to node 8 for a while…