### PR TITLE
Update readme to fix async code and variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,35 +41,37 @@ const Vision = require('vision');
 const HapiSwagger = require('hapi-swagger');
 const Pack = require('./package');
 
-const server = await new Hapi.Server({
-    host: 'localhost',
-    port: 3000
-});
-
-const options = {
-    info: {
-            'title': 'Test API Documentation',
-            'version': Pack.version,
+(async () => {
+    const server = await new Hapi.Server({
+        host: 'localhost',
+        port: 3000,
+    });
+    
+    const swaggerOptions = {
+        info: {
+                title: 'Test API Documentation',
+                version: Pack.version,
+            },
+        };
+    
+    await server.register([
+        Inert,
+        Vision,
+        {
+            plugin: HapiSwagger,
+            options: swaggerOptions
         }
-    };
-
-await server.register([
-    Inert,
-    Vision,
-    {
-        plugin: HapiSwagger,
-        options: swaggerOptions
+    ]);
+    
+    try {
+        await server.start();
+        console.log('Server running at:', server.info.uri);
+    } catch(err) {
+        console.log(err);
     }
-]);
-
-try {
-    await server.start();
-    console.log('Server running at:', server.info.uri);
-} catch(err) {
-    console.log(err);
-}
-
-server.route(Routes);
+    
+    server.route(Routes);
+)();
 ```
 
 # Tagging your API routes


### PR DESCRIPTION
This is just a quick update to change the README. It fixes a variable name in the quick start section and also fixes the async code as you cannot use `await` outside of an async function.

No changes to functional code.

```
183 tests complete
Test duration: 1894 ms
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```