### PR TITLE
fixed sample code of Quick Start. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const Pack = require('./package');
     }
     
     server.route(Routes);
-)();
+})();
 ```
 
 # Tagging your API routes


### PR DESCRIPTION
A closing curly bracket does not exist.
So I added id.