### PR TITLE
Properly handle forbiddenKeys in payload

### DIFF
--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -85,7 +85,7 @@ parameters.fromProperties = function(schemaObj, parameterType) {
         //console.log('b', JSON.stringify(schemaObj) + '\n');
 
         // object to array
-        const keys = Object.keys(schemaObj.properties);
+        const keys = Object.keys(schemaObj.properties).filter(key => schemaObj.properties[key] !== undefined);
         keys.forEach((element, index) => {
             let key = keys[index];
             let item = schemaObj.properties[key];


### PR DESCRIPTION
Forbidden keys, if present in the root schema object of the payload, cause error.
See https://github.com/glennjones/hapi-swagger/issues/328#issuecomment-367299587