### PR TITLE
JWT Tests and pin swagger-parser to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "http-status": "^1.0.1",
     "joi": "^13.1.2",
     "json-schema-ref-parser": "^4.1.0",
-    "swagger-parser": "^4.0.2"
+    "swagger-parser": "4.0.2"
   },
   "devDependencies": {
     "blipp": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hapi-api-version": "^1.4.0",
     "hapi-auth-basic": "^5.0.0",
     "hapi-auth-bearer-token": "^6.0.1",
-    "hapi-auth-jwt2": "^7.4.1",
+    "hapi-auth-jwt2": "^8.0.0",
     "husky": "^0.14.3",
     "inert": "^5.1.0",
     "js2xmlparser": "^3.0.0",

--- a/test/Integration/authentication-test.js
+++ b/test/Integration/authentication-test.js
@@ -7,7 +7,6 @@ const Validate = require('../../lib/validate.js');
 const expect = Code.expect;
 const lab = exports.lab = Lab.script();
 
-/* This set of test has been comment out until the JWT module has been upgraded to work with Hapi v17+
 lab.experiment('default `auth` settings', () => {
     const routes = [
         {
@@ -59,14 +58,13 @@ lab.experiment('default `auth` settings', () => {
             url: '/documentation'
         };
 
-        const server = await Helper.createJWTAuthServer({ auth: undefined });
+        const server = await Helper.createJWTAuthServer({ auth: undefined }, routes);
         const response = await server.inject(requestOptions);
         expect(response.statusCode).to.equal(401);
     });
 
 
 });
-*/
 
 
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,6 @@ const Boom = require('boom');
 const Inert = require('inert');
 const Vision = require('vision');
 const Wreck = require('wreck');
-// const JWT = require('jsonwebtoken');
 const HapiSwagger = require('../lib/index.js');
 
 const helper = module.exports = {};
@@ -113,7 +112,7 @@ helper.createJWTAuthServer = async(swaggerOptions, routes) => {
         Vision,
         require('hapi-auth-jwt2'),
         {
-            register: HapiSwagger,
+            plugin: HapiSwagger,
             options: swaggerOptions
         }
     ]);
@@ -129,6 +128,7 @@ helper.createJWTAuthServer = async(swaggerOptions, routes) => {
 
     server.route(routes);
     await server.start();
+    return server;
 
 };
 


### PR DESCRIPTION
- add back JWT tests
- pin swagger-parser to `v4.0.2`. [PR #83](https://github.com/BigstickCarpet/swagger-parser/pull/83) and [PR #84](https://github.com/BigstickCarpet/swagger-parser/pull/84), were added to improve the the [`validate()` method](https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/swagger-parser.md#validateapi-options-callback) and should  now detect when a JSON Schema in an API definition has `required` properties that don't exist. Unfortunately, the fixes don't take into account `$ref` which caused two unit test to break:
```
129) responses array with required #249:

      Expected false to be true

      at lab.test (/.hapi-swagger-fixes/test/Integration/responses-tests.js:697:35

130) responses replace example with x-example for response:

      Expected false to be true

      at lab.test (./hapi-swagger-fixes/test/Integration/responses-tests.js:755:35
````