### PR TITLE
add getHost property to swagger options for running custom getHost func

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -66,21 +66,19 @@ builder.schema = Joi.object({
 builder.getSwaggerJSON = async (settings, request) => {
     // remove items that cannot be changed by user
     delete settings.swagger;
-
     // collect root information
-    builder.default.host = internals.getHost(request);
+    builder.default.host = settings.getHost ? settings.getHost(request) : internals.getHost(request);
     builder.default.schemes = [internals.getSchema(request)];
-
     settings = Hoek.applyToDefaults(builder.default, settings);
     if (settings.basePath !== '/') {
         settings.basePath = Utilities.removeTrailingSlash(settings.basePath);
     }
+
     let out = internals.removeNoneSchemaOptions(settings);
     Joi.assert(out, builder.schema);
-
+    
     out.info = Info.build(settings);
     out.tags = Tags.build(settings);
-
     let routes = request.server.table();
 
     routes = Filter.byTags(['api'], routes);
@@ -99,7 +97,6 @@ builder.getSwaggerJSON = async (settings, request) => {
         routes,
         settings.pathReplacements
     );
-
     let paths = new Paths(settings);
     let pathData = paths.build(routes);
     out.paths = pathData.paths;
@@ -236,7 +233,8 @@ internals.removeNoneSchemaOptions = function(options) {
         'cache',
         'pathReplacements',
         'log',
-        'cors'
+        'cors',
+        'getHost'
     ].forEach(element => {
         delete out[element];
     });

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -25,5 +25,6 @@ module.exports = {
     'deReference': false,
     'validatorUrl': '//online.swagger.io/validator',
     'acceptToProduce': true,  // internal, NOT public
-    'pathReplacements': []
+    'pathReplacements': [],
+    'getHost': undefined,
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,8 @@ const schema = Joi.object({
         replaceIn: Joi.string().valid(['groups', 'endpoints', 'all']),
         pattern: Joi.object().type(RegExp),
         replacement: Joi.string().allow('')
-    }))
+    })),
+    getHost: Joi.func(),
 }).unknown();
 
 /**
@@ -106,7 +107,6 @@ exports.plugin = {
                 handler: async (request, h) => {
 
                     Joi.assert(settings, schema);
-
                     if (settings.cache) {
                         const { cached, value } = await server.methods.getSwaggerJSON(settings, request);
                         const lastModified = cached ? new Date(cached.stored) : new Date();

--- a/test/Integration/builder-test.js
+++ b/test/Integration/builder-test.js
@@ -82,7 +82,7 @@ lab.experiment('builder', () => {
             'externalDocs': {
                 'description': 'Find out more about HAPI',
                 'url': 'http://hapijs.com'
-            }
+            },
         };
 
         const server = await Helper.createServer(swaggerOptions, routes);
@@ -101,7 +101,27 @@ lab.experiment('builder', () => {
     });
 
 
+    lab.test('set values for swagger root object properties using special property getHost', async() => {
 
+        const swaggerOptions = {
+            'swagger': '5.9.45',
+            'schemes': ['https'],
+            'basePath': '/base',
+            'consumes': ['application/x-www-form-urlencoded'],
+            'produces': ['application/json', 'application/xml'],
+            'externalDocs': {
+                'description': 'Find out more about HAPI',
+                'url': 'http://hapijs.com'
+            },
+            'getHost': (req)=>req.headers['header-with-host']
+        };
+
+        const server = await Helper.createServer(swaggerOptions, routes);
+        const response = await server.inject({ headers: { 'header-with-host': 'localhost2' }, method: 'GET', url: '/swagger.json' });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.host).to.equal('localhost2');
+    });
 
     lab.test('xProperties : false', async() => {
 


### PR DESCRIPTION
Came across this issue when trying to deploy services using minikube. Minikube does a kind of reverse proxy, providing the actual host through the host header. I figured this is too chimerical to add another possible header to the getHost function, and that the option of providing a custom getHost function would solve the issue.