### PR TITLE
Rename config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ HTML page (see next section).
 {
     method: 'GET',
     path: '/todo/{id}/',
-    config: {
+    options: {
         handler: handlers.getToDo,
         description: 'Get todo',
         notes: 'Returns a todo item by the id passed in the path',


### PR DESCRIPTION
Since hapi v17 the "config" property is named "options" (see "Breaking Changes" in https://github.com/hapijs/hapi/issues/3658).