### PR TITLE
Removes `type` field from arrays when `$ref` is present

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -171,8 +171,7 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
         if (useDefinitions === true) {
             let refName = this.definitions.append(name, property, this.getDefinitionCollection(isAlt), this.settings);
             property = {
-                '$ref': this.getDefinitionRef(isAlt) + refName,
-                'type': 'array'
+                '$ref': this.getDefinitionRef(isAlt) + refName
             };
         }
     }

--- a/test/Integration/builder-test.js
+++ b/test/Integration/builder-test.js
@@ -125,8 +125,7 @@ lab.experiment('builder', () => {
                         'type': 'string'
                     },
                     'array': {
-                        '$ref': '#/definitions/array',
-                        'type': 'array'
+                        '$ref': '#/definitions/array'
                     }
                 }
             }
@@ -168,8 +167,7 @@ lab.experiment('builder', () => {
                         }
                     },
                     'array': {
-                        '$ref': '#/definitions/array',
-                        'type': 'array'
+                        '$ref': '#/definitions/array'
                     }
                 }
             }
@@ -282,5 +280,3 @@ lab.experiment('builder', () => {
     });
 
 });
-
-

--- a/test/Integration/child-model.js
+++ b/test/Integration/child-model.js
@@ -184,21 +184,18 @@ lab.experiment('child-models', () => {
             response.result.paths['/bar/arrays'].post.parameters[0]
                 .schema
         ).to.equal({
-            type: 'array',
             $ref: '#/definitions/FooArrParent'
         });
         expect(
             response.result.paths['/bar/arrays'].post.responses[200]
                 .schema
         ).to.equal({
-            type: 'array',
             $ref: '#/definitions/FooArrParent'
         });
         expect(response.result.definitions.FooArrParent).to.equal({
             type: 'array',
             items: {
-                $ref: '#/definitions/FooArr',
-                type: 'array'
+                $ref: '#/definitions/FooArr'
             }
         });
         expect(response.result.definitions.FooArr).to.equal({

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -461,8 +461,7 @@ lab.experiment('responses', () => {
         ).to.equal({
             description: 'Success',
             schema: {
-                $ref: '#/definitions/HTTP200',
-                type: 'array'
+                $ref: '#/definitions/HTTP200'
             }
         });
         expect(response.result.definitions.HTTP200).to.equal({

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -56,7 +56,7 @@ lab.experiment('property - ', () => {
         expect(propertiesNoAlt.parseProperty('x', Joi.boolean(), null, 'body', true, false)).to.equal({ 'type': 'boolean' });
         expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
         expect(propertiesNoAlt.parseProperty('x', Joi.binary(), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'binary' });
-        expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', true, false)).to.equal({ '$ref': '#/definitions/Model 1', 'type': 'array' });
+        expect(propertiesNoAlt.parseProperty('x', Joi.array(), null, 'body', true, false)).to.equal({ '$ref': '#/definitions/Model 1' });
         expect(propertiesNoAlt.parseProperty('x', Joi.any(), null, 'body', true, false)).to.equal({ 'type': 'string' });
         //expect(propertiesNoAlt.parseProperty('x', Joi.func(), null, 'body', true, false)).to.equal({ 'type': 'string' });
 
@@ -266,8 +266,7 @@ lab.experiment('property - ', () => {
         clearDown();
         //console.log(JSON.stringify(propertiesNoAlt.parseProperty('x', Joi.array().items({ 'text': Joi.string() }), null, 'formData', true, false)));
         expect(propertiesNoAlt.parseProperty('x', Joi.array().items(Joi.string()), null, 'formData', true, false)).to.equal({
-            '$ref': '#/definitions/x',
-            'type': 'array'
+            '$ref': '#/definitions/x'
         });
         //console.log(JSON.stringify(definitionCollection));
         expect(definitionCollection).to.equal({


### PR DESCRIPTION
When using $refs [all sibling elements are ignored][1] and causes [https://editor.swagger.io][2] to display an error when parsing `swagger.json` files produced by `hapi-swagger`.

Fixes #517

[1]: https://swagger.io/docs/specification/using-ref/#sibling
[2]: https://editor.swagger.io