### PR TITLE
fix: Use the incoming request to determine the host and port

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -147,8 +147,9 @@ builder.dereference = async (schema) => {
  * @return {String}
  */
 internals.getHost = function(request) {
-    let host = request.info.hostname;
-    const port = request.server.info.port;
+    const reqHost = request.info.host;
+    let host = reqHost.split(':')[0];
+    let port = reqHost.split(':')[1] || '';
     const protocol = request.server.info.protocol;
 
     // do not set port if its protocol http/https with default post numbers

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -147,27 +147,28 @@ builder.dereference = async (schema) => {
  * @return {String}
  */
 internals.getHost = function(request) {
-    const reqHost = request.info.host;
-    let host = reqHost.split(':')[0];
-    let port = reqHost.split(':')[1] || '';
+    const proxyHost = request.headers['x-forwarded-host'] || request.headers['disguised-host'] || '';
+    if (proxyHost) {
+        return proxyHost;
+    }
+
+    const reqHost = request.info.host.split(':');
+    const host = reqHost[0];
+    const port = parseInt(reqHost[1] || '', 10);
     const protocol = request.server.info.protocol;
 
     // do not set port if its protocol http/https with default post numbers
     // this cannot be tested on most desktops as ports below 1024 throw EACCES
     /* $lab:coverage:off$ */
-    if (
-        (port && (protocol === 'http' && port !== 80)) ||
-        (protocol === 'https' && port !== 443)
+    if (!isNaN(port) &&
+        ((protocol === 'http' && port !== 80) ||
+        (protocol === 'https' && port !== 443))
     ) {
-        host += ':' + port;
+        return host + ':' + port;
     }
     /* $lab:coverage:on$ */
 
-    return (
-        request.headers['x-forwarded-host'] ||
-        request.headers['disguised-host'] ||
-        host
-    );
+    return host;
 };
 
 /**

--- a/test/Integration/builder-test.js
+++ b/test/Integration/builder-test.js
@@ -250,6 +250,26 @@ lab.experiment('builder', () => {
         expect(isValid).to.be.true();
     });
 
+    lab.test('getSwaggerJSON determines host and port from request info', async () => {
+
+        const server = await Helper.createServer({});
+
+        const response = await server.inject({ method: 'GET', headers: { host: '194.418.15.24:7645' }, url: '/swagger.json' });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.host).to.equal('194.418.15.24:7645');
+    });
+
+    lab.test('getSwaggerJSON doesn\'t specify port from request info when port is default', async () => {
+
+        const server = await Helper.createServer({});
+
+        const response = await server.inject({ method: 'GET', headers: { host: '194.418.15.24:80' }, url: '/swagger.json' });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.host).to.equal('194.418.15.24');
+    });
+
 });
 
 


### PR DESCRIPTION
This fixes issues when the hapi server is running on a different host/port to the external interface, e.g. within Docker.

Fix #497 