### PR TITLE
Fix issue when field examples not appear correctly in swagger.json and swagger-ui

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -218,7 +218,10 @@ internals.properties.prototype.parsePropertyMetadata = function (property, name,
         internals.convertRules(property, describe.rules, [
             'unit'
         ], 'x-format');
-        property.example = Hoek.reach(joiObj, '_examples.0');
+        let exampleObj = Hoek.reach(joiObj, '_examples.0');
+        /* $lab:coverage:off$ */
+        property.example = exampleObj && exampleObj.value ? exampleObj.value : exampleObj;
+        /* $lab:coverage:on$ */
         property['x-meta'] = Hoek.reach(joiObj, '_meta.0');
     }
 


### PR DESCRIPTION
Fixed an issue #572: "field examples not appear correctly in swagger.json and swagger-ui"