### PR TITLE
Ignore date.min() and date.max() to avoid creating invalid swagger

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -265,8 +265,10 @@ internals.properties.prototype.parseString = function (property, joiObj) {
 
     const describe = joiObj.describe();
 
-    property.minLength = internals.getArgByName(describe.rules, 'min');
-    property.maxLength = internals.getArgByName(describe.rules, 'max');
+    if (describe.type !== 'date') {
+        property.minLength = internals.getArgByName(describe.rules, 'min');
+        property.maxLength = internals.getArgByName(describe.rules, 'max');
+    }
 
     // add regex
     joiObj._tests.forEach((test) => {

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -203,6 +203,16 @@ lab.experiment('property - ', () => {
         clearDown();
         expect(propertiesNoAlt.parseProperty('x', Joi.date(), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
 
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974'), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min('now'), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min(Joi.ref('y')), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max('1-1-1974'), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max('now'), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().max(Joi.ref('y')), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+
+        expect(propertiesNoAlt.parseProperty('x', Joi.date().min('1-1-1974').max('now'), null, 'body', true, false)).to.equal({ 'type': 'string', 'format': 'date' });
+
         /*  not yet 'x',
         date.min(date)
         date.max(date)

--- a/usageguide.md
+++ b/usageguide.md
@@ -493,6 +493,7 @@ Not all the flexibility of HAPI and JOI can to ported over to the Swagger schema
 * __`.allow( null )`__  The current Swagger spec does not support `null`. This __maybe__ added to the next version of OpenAPI spec.
 * __`payload: function (value, options, next) {next(null, value);}`__  The use of custom functions to validate pramaters is not support beyond replacing them with an emtpy model call "Hidden Model".
 * __`Joi.date().format('yy-mm-dd')` __ The use of a `moment` pattern to format a date cannot be reproduced in Swagger
+* __`Joi.date().min()` and `Joi.date().max()`__ Minimum or maximum dates cannot be expressed in Swagger.
 
 
 # Known issues with `jsonEditor`


### PR DESCRIPTION
Currently using date().min() and date().max() will result in an invalid swagger.json,
for example:

`date().min('1-1-1974')` will result in

```json
{
  "format": "date",
  "maxLength": "now",
   "type": "string"
}
```

Which is both invalid since maxLength must be an integer and obviously not what is meant by the Joi schema.

Couldn't find a reference that OpenAPI indeed doesn't support date range rules, but found no refrence that it does support it either.

Fixes #417