### PR TITLE
Upgrade json-schema-ref-parser to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,7 +187,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2237,8 +2236,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "optional": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -2436,14 +2434,32 @@
       "dev": true
     },
     "json-schema-ref-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-4.1.0.tgz",
-      "integrity": "sha512-xiTwbw9Bl9HLEKjFSUfTJmdMSTBaGvV/qjbEMzM5Db3rEBIMWgz/pFtzxZxeuc+s3gYkInUCMZl/8qc1bRPHkQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
       "requires": {
         "call-me-maybe": "^1.0.1",
-        "debug": "^3.1.0",
-        "js-yaml": "^3.10.0",
-        "ono": "^4.0.3"
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "ono": {
+          "version": "4.0.11",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+          "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+          "requires": {
+            "format-util": "^1.0.3"
+          }
+        }
       }
     },
     "json-schema-traverse": {
@@ -2536,7 +2552,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2894,8 +2909,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -3359,8 +3373,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.83.0",
@@ -3741,6 +3754,19 @@
         "swagger-methods": "^1.0.4",
         "swagger-schema-official": "2.0.0-bab6bed",
         "z-schema": "^3.19.0"
+      },
+      "dependencies": {
+        "json-schema-ref-parser": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-4.1.1.tgz",
+          "integrity": "sha512-lByoCHZ6H2zgb6NtsXIqtzQ+6Ji7iVqnrhWxsXLhF+gXmgu6E8+ErpDxCMR439MUG1nfMjWI2HAoM8l0XgSNhw==",
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "debug": "^3.1.0",
+            "js-yaml": "^3.10.0",
+            "ono": "^4.0.3"
+          }
+        }
       }
     },
     "swagger-schema-official": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "hoek": "^6.1.2",
         "http-status": "^1.0.1",
         "joi": "^13.1.2",
-        "json-schema-ref-parser": "^4.1.0",
+        "json-schema-ref-parser": "^6.1.0",
         "swagger-parser": "4.0.2"
     },
     "devDependencies": {


### PR DESCRIPTION
I noticed that this was out of date (as well as joi, which I saw that you're working on https://github.com/glennjones/hapi-swagger/issues/577).

Also, is there any plan to upgrade `swagger-parser` beyond 4.0.2, after they made the validate function stricter? That upgrade breaks 3 tests because they are missing parameters, but fixing that would unlock swagger v3