### PR TITLE
Docs: explain how to use Hapi.js `response.status` for multiple status codes

### DIFF
--- a/usageguide.md
+++ b/usageguide.md
@@ -319,7 +319,7 @@ config: {
                 description : 'Bad Request'
             }
         }
-    }
+    },
     validate: {
         params: {
             a: Joi.number()

--- a/usageguide.md
+++ b/usageguide.md
@@ -337,12 +337,17 @@ config: {
 Note: The `Reason` box in Swagger-UI for the response will take the value of the default description of its' corresponding status code.
 For example:
 - 200 -> `Successful`
+- 400 -> `Bad Request`
 - 404 -> `Not Found`
 
 Basically, Swagger requires a `description` for each response, and by taking the default description we can overcome this requirement.
 
 However, if one wishes to provide a custom `description`, then hapi-swagger offers the `plugins.hapi-swager.responses` option in which response objects specify a `description` key which allows this.
 With this option, the `description` is required, the `schema` is optional, and unlike `response.status`  option above, the schema object does not validate the API response.
+
+In the following example, the `Reason` box in Swagger-UI will show the following descriptions:
+- 200 -> `Smooth sail`
+- 400 -> `Something wrong happened`
 
 ```Javascript
 config: {
@@ -354,13 +359,13 @@ config: {
         'hapi-swagger': {
             responses: {
                 200: {
-                    description: 'Success',
+                    description: 'Smooth sail',
                     schema: Joi.object({
                             equals: Joi.number(),
                         }).label('Result')
                 },
                 400: {
-                    description: 'Bad Request'
+                    description: 'Something wrong happened'
                 }
             }
         }

--- a/usageguide.md
+++ b/usageguide.md
@@ -1,37 +1,26 @@
 # 9.0.0 Usage Guide
 
 ### Content
-- [9.0.0 Usage Guide](#900-usage-guide)
-    - [Content](#content)
-    - [Links](#links)
-- [JSON body](#json-body)
-- [Form body](#form-body)
-- [Params query and headers](#params-query-and-headers)
-- [Naming](#naming)
-- [Grouping endpoints by path or tags](#grouping-endpoints-by-path-or-tags)
-- [Extending group information with tag objects](#extending-group-information-with-tag-objects)
-- [Ordering the endpoints within groups](#ordering-the-endpoints-within-groups)
-- [Rewriting paths and groupings](#rewriting-paths-and-groupings)
-    - [Option 1 `basePath` and `pathPrefixSize`](#option-1-basepath-and-pathprefixsize)
-    - [Option 2 `pathReplacements`](#option-2-pathreplacements)
-- [Response Object](#response-object)
-- [Status Codes](#status-codes)
-- [Caching](#caching)
-- [File upload](#file-upload)
-- [Default values and examples](#default-values-and-examples)
-- [Headers and .unknown()](#headers-and-unknown)
-- [Additional HAPI data using `x-*`](#additional-hapi-data-using-x)
-- [JSON without UI](#json-without-ui)
-- [Simplifying the JSON](#simplifying-the-json)
-- [Debugging](#debugging)
-- [Features from HAPI that cannot be ported to Swagger](#features-from-hapi-that-cannot-be-ported-to-swagger)
-- [Known issues with `jsonEditor`](#known-issues-with-jsoneditor)
-- [Adding the interface into your own custom page](#adding-the-interface-into-your-own-custom-page)
-    - [Adding the javascript](#adding-the-javascript)
-    - [Adding the HTML elements](#adding-the-html-elements)
-    - [Custom tag-specific documentation](#custom-tag-specific-documentation)
-- [Example code in project](#example-code-in-project)
-- [External example projects](#external-example-projects)
+* [JSON body](#json-body)
+* [Form body](#form-body)
+* [Params query and headers](#params-query-and-headers)
+* [Naming](#naming)
+* [Grouping endpoints by path or tags](#grouping-endpoints-by-path-or-tags)
+* [Extending group information with tag objects](#extending-group-information-with-tag-objects)
+* [Ordering the endpoints within groups](#ordering-the-endpoints-within-groups)
+* [Rewriting paths and groupings](#rewriting-paths-and-groupings)
+* [Response Object](#response-object)
+* [Status Codes](#status-codes)
+* [Caching](#caching)
+* [File upload](#file-upload)
+* [Headers and .unknown()](#headers-and-unknown)
+* [Additional HAPI data using x-*](#additional-hapi-data-using-x-)
+* [JSON without UI](#json-without-ui)
+* [Simplifying the JSON](#simplifying-the-json)
+* [Debugging](#debugging)
+* [Features from HAPI that cannot be ported to Swagger](#features-from-hapi-that-cannot-be-ported-to-swagger)
+* [Known issues with `jsonEditor`](#known-issues-with-jsoneditor)
+* [Adding the interface into your own custom page](#adding-the-interface-into-your-own-custom-page)
 
 ### Links
 * [Example code in project](#example-code-in-project)
@@ -389,7 +378,6 @@ config: {
     }
 }
 ```
-
 
 # Caching
 It can take some time to create the `swagger.json` data if your server has many complex routes. So `hapi-swagger`


### PR DESCRIPTION
Not sure what version Hapi.js introduced the `response.status` but after trying it out with hapi-swagger today it turns out that Swagger-UI does recognize this option, however the Docs didn't demonstrate this so I decided to write about it.

If there is some limitation with this option, please let me know.
I made sure to document the differences between the `response.status` and the `plugin.hapi-swagger.responses` options for full clarification.