### PR TITLE
feat: add support for additional properties in object schemas

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -157,7 +157,7 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
       }
     }
 
-    const allowUnknown = (joiObj._flags || {}).allowUnknown;
+    const allowUnknown = joiObj._flags.allowUnknown;
     if (allowUnknown !== undefined && !allowUnknown) {
       property.additionalProperties = false;
     }

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -156,6 +156,11 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
         };
       }
     }
+
+    const allowUnknown = (joiObj._flags || {}).allowUnknown;
+    if (allowUnknown !== undefined && !allowUnknown) {
+      property.additionalProperties = false;
+    }
   }
 
   // add array properties

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -575,6 +575,7 @@ lab.test('parse type object', () => {
       }
     }
   });
+  expect(propertiesNoAlt.parseProperty('x', Joi.object().unknown(false), null, 'body', false, false)).to.equal({type: 'object', additionalProperties: false})
   expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
     name: 'x',
     type: 'object',
@@ -606,7 +607,7 @@ lab.experiment('property deep - ', () => {
         .max(10)
         .required()
         .label('inner2')
-    })
+    }).unknown(false)
   });
 
   //console.log(JSON.stringify( propertiesNoAlt.parseProperty( deepStructure, {}, {}, null, false ) ));
@@ -631,6 +632,7 @@ lab.experiment('property deep - ', () => {
           required: ['inner1']
         },
         outer2: {
+          additionalProperties: false,
           name: 'outer2',
           type: 'object',
           properties: {


### PR DESCRIPTION
This PR adds `additionalProperties` keyword on the generated schema, when Joi object is created with `unkown(false)` option