### PR TITLE
Fix: Validating and documenting a 204 No Content endpoint

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -145,7 +145,9 @@ internals.responses.prototype.getResponse = function(statusCode, joiObj, useDefi
 
   out.headers = Utilities.getJoiMetaProperty(joiObj, 'headers');
   out.examples = Utilities.getJoiMetaProperty(joiObj, 'examples');
-  delete out.schema['x-meta'];
+  if (out.schema !== undefined) {
+    delete out.schema['x-meta'];
+  }
   out = Utilities.deleteEmptyProperties(out);
 
   // default description if not given

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -212,6 +212,7 @@ lab.experiment('responses', () => {
         response: {
           status: {
             200: joiSumModel,
+            204: undefined,
             400: err400,
             404: err404,
             429: err429,


### PR DESCRIPTION
Ref.: https://github.com/glennjones/hapi-swagger/issues/392