### PR TITLE
fix: add documentationRouteTags to swagger ui assets routes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,7 @@ exports.plugin = {
               path: `${settings.swaggerUIPath}${filename}`,
               options: {
                 auth: settings.auth,
+                tags: settings.documentationRouteTags,
                 files: {
                   relativeTo: swaggerUiAssetPath
                 }


### PR DESCRIPTION
closes issue #612