### PR TITLE
Fix pattern generation to avoid truncating regex at internal "/"

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -286,7 +286,10 @@ internals.properties.prototype.parseString = function(property, joiObj) {
   joiObj._rules.forEach(test => {
     if (Utilities.isObject(test.args) && test.args.regex) {
       if (Utilities.isRegex(test.args.regex)) {
-        property.pattern = test.args.regex.toString().split('/')[1]
+        // get the regex source (as opposed to regex.toString()) so
+        // we exclude the surrounding '/' delimeters as well as any
+        // trailing flags (g, i, m)
+        property.pattern = test.args.regex.source;
       } else {
         property.pattern = test.args.regex;
       }

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -198,6 +198,16 @@ lab.experiment('property - ', () => {
       type: 'string',
       pattern: '^[a-zA-Z0-9]{3,30}'
     });
+    // covers https://github.com/glennjones/hapi-swagger/issues/652 -
+    // make sure we aren't truncating the regex after an internal '/',
+    // and make sure we omit any regex flags (g, i, m) from the
+    // resulting pattern
+    expect(
+      propertiesNoAlt.parseProperty('x', Joi.string().regex(/^https:\/\/test.com/mi), null, 'body', true, false)
+    ).to.equal({
+      type: 'string',
+      pattern: '^https:\\/\\/test.com'
+    });
 
     expect(propertiesAlt.parseProperty('x', Joi.string().length(0, 'utf8'), null, 'body', true, false)).to.equal({
       type: 'string',


### PR DESCRIPTION
Fixes https://github.com/glennjones/hapi-swagger/issues/652

I had to `--no-verify` when committing because the code coverage threshold did not pass when the testsuite was limited to just the single file that was updated (lib/properties.js), which is how it runs from within `lint-staged`, however the overall coverage percentage (when run directly as `npm test`) is still showing 98.05%.