### PR TITLE
Support for hiding Joi properties from being included in Swagger

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -73,6 +73,9 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
     return undefined;
   }
 
+  if (Utilities.getJoiMetaProperty(joiObj, 'swaggerHidden') === true) {
+    return undefined;
+  }
   // default the use of definitions to true
   if (useDefinitions === undefined || useDefinitions === null) {
     useDefinitions = true;

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -179,6 +179,18 @@ lab.experiment('property - ', () => {
     expect(nonNegativeWithoutDropdown).to.not.include({ enum: [0] });
   });
 
+  lab.test('parse hidden', () => {
+    expect(
+      propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: true }), null, 'body', true, false)
+    ).to.equal(undefined);
+    expect(
+      propertiesAlt.parseProperty('x', Joi.string().meta({ swaggerHidden: false }), null, 'body', true, false)
+    ).to.equal({
+      type: 'string',
+      'x-meta': { swaggerHidden: false }
+    });
+  });
+
   lab.test('parse type string', () => {
     clearDown();
     expect(propertiesNoAlt.parseProperty('x', Joi.string(), null, 'body', true, false)).to.equal({

--- a/usageguide.md
+++ b/usageguide.md
@@ -14,6 +14,7 @@
 -   [Status Codes](#status-codes)
 -   [Caching](#caching)
 -   [File upload](#file-upload)
+-   [Prevent JOI properties from being included in the Swagger schema](#prevent-joi-properties-from-being-included-in-the-swagger-schema)
 -   [Headers and .unknown()](#headers-and-unknown)
 -   [Additional Hapi data using x-\*](#additional-hapi-data-using-x-)
 -   [JSON without UI](#json-without-ui)
@@ -467,6 +468,12 @@ the three important elements are:
         response: {schema : sumModel}
 }
 ```
+
+## Prevent JOI properties from being included in the Swagger schema
+
+You can prevent specific JOI properties from being included in the generated Swagger schema by using:
+
+`.meta({ swaggerHidden: true })`
 
 ## Default values and examples
 


### PR DESCRIPTION
Some properties that are used for internal purposes (and still need to be validated) are potentially unwanted in public-facing documentation. This PR adds support for such cases. Adding

`.meta({ swaggerHidden: true })`

will exclude property from the resulting spec.