### PR TITLE
handle regex as pattern schema

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -147,9 +147,11 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
       }
     } else if (joiObj.$_terms.patterns) {
       let objectPattern = joiObj.$_terms.patterns[0];
-      let patternSchema = objectPattern.schema;
-      let patternName = patternSchema.$_terms.examples
-      && patternSchema.$_terms.examples[0] ? patternSchema.$_terms.examples[0] : patternSchema.type;
+      let patternName = 'string';
+      if (objectPattern.schema) {
+        patternName = objectPattern.schema.$_terms.examples
+        && objectPattern.schema.$_terms.examples[0] ? objectPattern.schema.$_terms.examples[0] : objectPattern.schema.type;
+      }
       property.name = name;
       property.properties = {
         [patternName]: this.parseProperty(patternName, objectPattern.rule, property, parameterType, useDefinitions, isAlt),

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -590,7 +590,8 @@ lab.test('parse type object', () => {
         type: 'string'
       }
     }
-  });  expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
+  });
+  expect(propertiesNoAlt.parseProperty('x', Joi.object({ a: Joi.string() }), null, 'body', false, false)).to.equal({
     name: 'x',
     type: 'object',
     properties: {
@@ -601,7 +602,7 @@ lab.test('parse type object', () => {
   });
   // test without pattern schema example
   expect(propertiesNoAlt.parseProperty('x', Joi.object().pattern(Joi.string(), Joi.object({
-    y: Joi.string().example('b'),
+    y: Joi.string()
   })), null, 'body', false, false)).to.equal({
     name: 'x',
     type: 'object',
@@ -619,13 +620,31 @@ lab.test('parse type object', () => {
   });
   // test with pattern schema example
   expect(propertiesNoAlt.parseProperty('x', Joi.object().pattern(Joi.string().example('a'), Joi.object({
-    y: Joi.string().example('b'),
+    y: Joi.string()
   })), null, 'body', false, false)).to.equal({
     name: 'x',
     type: 'object',
     properties: {
       a: {
         name: 'a',
+        type: 'object',
+        properties: {
+          'y': {
+            type: 'string'
+          }
+        }
+      }
+    }
+  });
+  // test with regex as pattern
+  expect(propertiesNoAlt.parseProperty('x', Joi.object().pattern(/\w\d/, Joi.object({
+    y: Joi.string()
+  })), null, 'body', false, false)).to.equal({
+    name: 'x',
+    type: 'object',
+    properties: {
+      string: {
+        name: 'string',
         type: 'object',
         properties: {
           'y': {


### PR DESCRIPTION
- added a check to avoid 'undefined of' when using regex as property pattern
- added unit test to cover regex as object property pattern