### PR TITLE
Update @hapi/boom to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -169,6 +169,15 @@
         "@hapi/hoek": "8.x.x"
       },
       "dependencies": {
+        "@hapi/boom": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
+          "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "8.x.x"
+          }
+        },
         "@hapi/hoek": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
@@ -231,18 +240,11 @@
       }
     },
     "@hapi/boom": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
-      "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bossy": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=8.0.0"
   },
   "dependencies": {
-    "@hapi/boom": "^8.0.1",
+    "@hapi/boom": "^9.1.0",
     "@hapi/hoek": "^9.0.2",
     "handlebars": "^4.5.3",
     "http-status": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@hapi/boom": "^9.1.0",


### PR DESCRIPTION
Update the boom library to v9. According to it's [changelog](https://github.com/hapijs/boom/milestone/60?closed=1) the only breaking change is that is requires Node >= 12. Since this library already requires that version, it shouldn't be a problem. I also updated the `engines` field to reflect the actual Node.js support.