### PR TITLE
Updates JWT example to include Authorization headers

### DIFF
--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -19,7 +19,8 @@ let swaggerOptions = {
       name: 'Authorization',
       in: 'header'
     }
-  }
+  },
+  security: [{ jwt: [] }]
 };
 
 const people = {


### PR DESCRIPTION
Without the security property the authorization headers are never sent. I hope this helps other developers save time.

See: https://github.com/glennjones/hapi-swagger/issues/602#issuecomment-522129367