### PR TITLE
Replace @hapi/joi with joi, as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "peerDependencies": {
     "@hapi/hapi": "^19.0.0",
-    "@hapi/joi": "17.x"
+    "joi": "17.x"
   },
   "lint-staged": {
     "*.{js}": [


### PR DESCRIPTION
Due to the separation of Joi from Hapi, I replaced the old dependency with the new one