### PR TITLE
Implementing uiCompleteScript using both inline script or external URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,19 @@ const schema = Joi.object({
   sortTags: Joi.string().valid('alpha'),
   sortEndpoints: Joi.string().valid('alpha', 'method', 'ordered'),
   sortPaths: Joi.string().valid('unsorted', 'path-method'),
-  uiCompleteScript: Joi.string().allow(null),
+
+  // patch: uiCompleteScript -- Define validation scope
+  //        to have another ability, you may use plain js script as "string"
+  //        or use external file by describe it as { src: 'URL' }
+  //        you may provide external js file as URL from static route,
+  //        eg: '/assets/js/doc-patch.js'
+  uiCompleteScript: Joi.alternatives(
+    Joi.string(),
+    Joi.object()
+      .keys({
+        src: Joi.string().required()
+      })
+  ).allow(null),
   xProperties: Joi.boolean(),
   reuseDefinitions: Joi.boolean(),
   definitionPrefix: Joi.string(),
@@ -122,6 +134,21 @@ exports.plugin = {
         generateKey: (settings, request) => 'hapi-swagger-' + request.path
       };
       server.method('getSwaggerJSON', getSwaggerJSON, options);
+    }
+
+    // patch: uiCompleteScript -- Implementing
+    //        mutate the uiCompleteScript before render into h.views
+    if (
+      (settings.uiCompleteScript !== '') &&
+      (settings.uiCompleteScript !== null) &&
+      (typeof settings.uiCompleteScript === 'object')
+    ) {
+      settings.uiCompleteScript = `
+        const s = document.createElement('script');
+        s.src = '${settings.uiCompleteScript.src}';
+        s.type = 'text/javascript';
+        document.body.appendChild(s);
+      `;
     }
 
     Joi.assert(settings, schema);

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,11 @@
           docExpansion: "{{hapiSwagger.expanded}}",
           tagsSorter: apisSorter.{{hapiSwagger.sortTags}},
           operationsSorter: operationsSorter.{{hapiSwagger.sortEndpoints}},
+
+          // patch: uiCompleteScript -- Rendering
+          onComplete: function(){
+            {{{ hapiSwagger.uiCompleteScript }}}
+          }
         }
 
         var ui = SwaggerUIBundle(swaggerOptions);


### PR DESCRIPTION
There are 2 methods to use this ability.

1. Use inline script as plain string, eg:
```
{
  ...,
  uiCompleteScript: 'alert("I got you !")'
}
```
2. Well, I know the world is not enough to write ideas in people mind as script into a "string", then alternatively use External file as URL, you may define from Hapi static route or other source, eg:
```
{
  ...,
  uiCompleteScript: { src: '/assets/js/doc-patch.js' }
}
```
```
// example at external JS file (URL):  /assets/js/doc-patch.js
'use strict';

window.alert('I got you again .. ');
```