### PR TITLE
fix: Use default 200 response when responses empty & given default schema

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -41,7 +41,7 @@ internals.responses.prototype.build = function(
   let out = {};
 
   // add defaultSchema to statusSchemas if needed
-  if (Utilities.hasProperties(defaultSchema) && Hoek.reach(statusSchemas, '200') === undefined) {
+  if (Utilities.hasProperties(defaultSchema) && !Utilities.hasProperties(statusSchemas)) {
     statusSchemas[200] = defaultSchema;
   }
 

--- a/test/Integration/responses-tests.js
+++ b/test/Integration/responses-tests.js
@@ -464,6 +464,40 @@ lab.experiment('responses', () => {
     expect(isValid).to.be.true();
   });
 
+  lab.test('when default schema provided an no responses provided', async () => {
+    const routes = {
+      method: 'POST',
+      path: '/store/',
+      options: {
+        handler: Helper.defaultHandler,
+        tags: ['api'],
+        validate: {
+          payload: Joi.object({
+            a: Joi.number()
+              .required()
+              .description('the first number')
+          })
+        },
+        response: {
+          schema: joiListModel
+        }
+      }
+    };
+
+    const server = await Helper.createServer({}, routes);
+    const response = await server.inject({ url: '/swagger.json' });
+    expect(response.result.paths['/store/'].post.responses).to.equal({
+      200: {
+        schema: {
+          '$ref': '#/definitions/List'
+        },
+        description: 'Successful'
+      }
+    });
+    const isValid = await Validate.test(response.result);
+    expect(isValid).to.be.true();
+  });
+
   lab.test('No ownProperty', async () => {
     let objA = Helper.objWithNoOwnProperty();
     const objB = Helper.objWithNoOwnProperty();


### PR DESCRIPTION
Fix for https://github.com/glennjones/hapi-swagger/issues/695