### PR TITLE
Intermediate definitions for arrays of sub-schemas

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,16 @@
       "skipFiles": ["<node_internals>/**/*.js"],
       "disableOptimisticBPs": true,
       "sourceMaps": false
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "test using lab",
+      "program": "${workspaceFolder}/node_modules/.bin/lab",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**/*.js"],
+      "disableOptimisticBPs": true,
+      "sourceMaps": false
     }
   ],
   "inputs": [

--- a/index.d.ts
+++ b/index.d.ts
@@ -301,7 +301,7 @@ declare namespace hapiswagger {
      * 
      * @default: true
      */
-    definitionsForArraysOfObjects?: string;
+    definitionsForArraysOfObjects?: boolean;
 
     /**
      * Dereferences JSON output

--- a/index.d.ts
+++ b/index.d.ts
@@ -280,6 +280,30 @@ declare namespace hapiswagger {
     definitionPrefix?: string;
 
     /**
+     * Enable of disable generation of Definitions for array properties
+     * containing sub-schemas.
+     * 
+     * Given this Joi schema:
+     * 
+     * Joi.object({
+     *   items: Joi.array().items(
+     *     Joi.object({
+     *       value: Joi.string()
+     *     }).label('SubSchema')
+     *   )
+     * }).label('Schema');
+     * 
+     * `definitionsForArraysOfObjects=true` will generate linked definitions like this:
+     * `Schema` -> `items` -> `SubSchema`
+     * 
+     * `definitionsForArraysOfObjects=false` will generate linked definitions like this:
+     * `Schema` -> `SubSchema`
+     * 
+     * @default: true
+     */
+    definitionsForArraysOfObjects?: string;
+
+    /**
      * Dereferences JSON output
      *
      * @default: false

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -239,6 +239,7 @@ internals.removeNoneSchemaOptions = function(options) {
     'uiCompleteScript',
     'deReference',
     'definitionPrefix',
+    'definitionsForArraysOfObjects',
     'validatorUrl',
     'acceptToProduce',
     'cache',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -25,6 +25,7 @@ module.exports = {
   xProperties: true,
   reuseDefinitions: true,
   definitionPrefix: 'default',
+  definitionsForArraysOfObjects: true,
   deReference: false,
   validatorUrl: '//online.swagger.io/validator',
   acceptToProduce: true, // internal, NOT public

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ const schema = Joi.object({
   xProperties: Joi.boolean(),
   reuseDefinitions: Joi.boolean(),
   definitionPrefix: Joi.string(),
+  definitionsForArraysOfObjects: Joi.boolean(),
   deReference: Joi.boolean(),
   validatorUrl: Joi.string().allow(null),
   acceptToProduce: Joi.boolean(),
@@ -57,10 +58,7 @@ const schema = Joi.object({
     query: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
     payload: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
     state: Joi.alternatives(Joi.object(), Joi.array(), Joi.function()).allow(null, false, true),
-    failAction: Joi.alternatives([
-      Joi.valid('error', 'log', 'ignore'),
-      Joi.function()
-    ]),
+    failAction: Joi.alternatives([Joi.valid('error', 'log', 'ignore'), Joi.function()]),
     errorFields: Joi.object(),
     options: Joi.object(),
     validator: Joi.object()
@@ -83,7 +81,7 @@ exports.plugin = {
     // `options.validate` might not be present but it should not be set in the
     // `Defaults` since it would always override the server-level defaults.
     // It should be overwritten only if explicitly passed to the plugin options.
-    const validateOption = { validate: options.validate }
+    const validateOption = { validate: options.validate };
     let settings = Hoek.applyToDefaults(Defaults, options, { nullOverride: true });
     const publicDirPath = Path.resolve(__dirname, '..', 'public');
 
@@ -131,24 +129,27 @@ exports.plugin = {
       {
         method: 'GET',
         path: settings.jsonRoutePath,
-        options: Hoek.applyToDefaults({
-          auth: settings.auth,
-          cors: settings.cors,
-          tags: settings.documentationRouteTags,
-          handler: async (request, h) => {
-            if (settings.cache) {
-              const { cached, value } = await server.methods.getSwaggerJSON(settings, request);
-              const lastModified = cached ? new Date(cached.stored) : new Date();
-              return h.response(value).header('last-modified', lastModified.toUTCString());
-            } else {
-              const json = await Builder.getSwaggerJSON(settings, request);
-              return json;
+        options: Hoek.applyToDefaults(
+          {
+            auth: settings.auth,
+            cors: settings.cors,
+            tags: settings.documentationRouteTags,
+            handler: async (request, h) => {
+              if (settings.cache) {
+                const { cached, value } = await server.methods.getSwaggerJSON(settings, request);
+                const lastModified = cached ? new Date(cached.stored) : new Date();
+                return h.response(value).header('last-modified', lastModified.toUTCString());
+              } else {
+                const json = await Builder.getSwaggerJSON(settings, request);
+                return json;
+              }
+            },
+            plugins: {
+              'hapi-swagger': false
             }
           },
-          plugins: {
-            'hapi-swagger': false
-          }
-        }, validateOption)
+          validateOption
+        )
       }
     ]);
 
@@ -169,14 +170,17 @@ exports.plugin = {
             {
               method: 'GET',
               path: settings.documentationPath,
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                handler: (request, h) => {
-                  return h.view('index', {});
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  handler: (request, h) => {
+                    return h.view('index', {});
+                  },
+                  plugins: settings.documentationRoutePlugins
                 },
-                plugins: settings.documentationRoutePlugins
-              }, validateOption)
+                validateOption
+              )
             }
           ]);
         }
@@ -201,13 +205,16 @@ exports.plugin = {
             server.route({
               method: 'GET',
               path: `${settings.routesBasePath}${filename}`,
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                files: {
-                  relativeTo: swaggerUiAssetPath
-                }
-              }, validateOption),
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  files: {
+                    relativeTo: swaggerUiAssetPath
+                  }
+                },
+                validateOption
+              ),
               handler: {
                 file: `${filename}`
               }
@@ -217,16 +224,19 @@ exports.plugin = {
           server.route({
             method: 'GET',
             path: settings.routesBasePath + 'extend.js',
-            options: Hoek.applyToDefaults({
-              tags: settings.documentationRouteTags,
-              auth: settings.auth,
-              files: {
-                relativeTo: publicDirPath
+            options: Hoek.applyToDefaults(
+              {
+                tags: settings.documentationRouteTags,
+                auth: settings.auth,
+                files: {
+                  relativeTo: publicDirPath
+                },
+                handler: {
+                  file: 'extend.js'
+                }
               },
-              handler: {
-                file: 'extend.js'
-              }
-            }, validateOption)
+              validateOption
+            )
           });
         }
 
@@ -238,14 +248,17 @@ exports.plugin = {
               path: join(settings.documentationPath, sep, 'debug')
                 .split(sep)
                 .join('/'),
-              options: Hoek.applyToDefaults({
-                auth: settings.auth,
-                tags: settings.documentationRouteTags,
-                handler: (request, h) => {
-                  return h.view('debug.html', {}).type('application/json');
+              options: Hoek.applyToDefaults(
+                {
+                  auth: settings.auth,
+                  tags: settings.documentationRouteTags,
+                  handler: (request, h) => {
+                    return h.view('debug.html', {}).type('application/json');
+                  },
+                  plugins: settings.documentationRoutePlugins
                 },
-                plugins: settings.documentationRoutePlugins
-              }, validateOption)
+                validateOption
+              )
             }
           ]);
         }
@@ -279,7 +292,7 @@ exports.plugin = {
  * @param  {Object} settings
  * @return {Object}
  */
-const appendDataContext = function (plugin, settings) {
+const appendDataContext = function(plugin, settings) {
   plugin.ext('onPostHandler', (request, h) => {
     let response = request.response;
     // if the reply is a view add settings data into template system
@@ -328,7 +341,7 @@ const appendDataContext = function (plugin, settings) {
  * @param  {String} qsValue
  * @return {String}
  */
-const appendQueryString = function (url, qsName, qsValue) {
+const appendQueryString = function(url, qsName, qsValue) {
   let urlObj = Url.parse(url);
   if (qsName && qsValue) {
     urlObj.query = Querystring.parse(qsName + '=' + qsValue);
@@ -345,7 +358,7 @@ const appendQueryString = function (url, qsName, qsValue) {
  * @param  {Object} settings
  * @return {String}
  */
-const findAPIKeyPrefix = function (settings) {
+const findAPIKeyPrefix = function(settings) {
   // Need JWT plugin to work with Hapi v17+ to test this again
   /* $lab:coverage:off$ */
   let out = '';

--- a/lib/properties.js
+++ b/lib/properties.js
@@ -190,7 +190,9 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
   if (property.type === 'array') {
     property = this.parseArray(property, joiObj, name, parameterType, useDefinitions, isAlt);
 
-    if (useDefinitions === true) {
+    // this.settings is frequently 'false' in tests
+    const createDefinitionsForArraysOfObjects = !this.settings || this.settings.definitionsForArraysOfObjects === true;
+    if (useDefinitions === true && createDefinitionsForArraysOfObjects) {
       let refName = this.definitions.append(name, property, this.getDefinitionCollection(isAlt), this.settings);
       property = {
         $ref: this.getDefinitionRef(isAlt) + refName

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -811,6 +811,133 @@ lab.experiment('property deep - ', () => {
       type: 'object'
     });
   });
+
+  lab.test(
+    'naming behavior with useLabels and reuseDefinitions=false - for objects with arrays of like objects',
+    async () => {
+      clearDown();
+
+      const innerSchema = Joi.object({
+        value: Joi.string()
+      });
+
+      const schema1 = Joi.object({
+        ones: Joi.array().items(innerSchema.label('One'))
+      }).label('Ones');
+
+      const routes = [
+        {
+          method: 'GET',
+          path: '/path/one',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            response: {
+              schema: schema1
+            }
+          }
+        }
+      ];
+
+      const server = await Helper.createServer(
+        {
+          reuseDefinitions: false,
+          definitionPrefix: 'useLabel'
+        },
+        routes
+      );
+      const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+      expect(response.result.definitions.Ones).to.equal({
+        properties: {
+          ones: {
+            $ref: '#/definitions/ones'
+          }
+        },
+        type: 'object'
+      });
+
+      // This is an invented definition
+      expect(response.result.definitions.ones).to.equal({
+        items: {
+          $ref: '#/definitions/One'
+        },
+        type: 'array'
+      });
+
+      expect(response.result.definitions.One).to.equal({
+        properties: {
+          value: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      });
+    }
+  );
+
+  lab.test(
+    'naming behavior with useLabels and reuseDefinitions=false and dontInventSubSchemaArrayDefinitions=true - for objects with arrays of like objects',
+    async () => {
+      clearDown();
+
+      const innerSchema = Joi.object({
+        value: Joi.string()
+      });
+
+      const schema1 = Joi.object({
+        ones: Joi.array().items(innerSchema.label('One'))
+      }).label('Ones');
+
+      const routes = [
+        {
+          method: 'GET',
+          path: '/path/one',
+          options: {
+            tags: ['api'],
+            handler: Helper.defaultHandler,
+            response: {
+              schema: schema1
+            }
+          }
+        }
+      ];
+
+      const server = await Helper.createServer(
+        {
+          reuseDefinitions: false,
+          definitionPrefix: 'useLabel',
+          definitionsForArraysOfObjects: false
+        },
+        routes
+      );
+      const response = await server.inject({ method: 'GET', url: '/swagger.json' });
+
+      expect(response.result.definitions.Ones).to.equal({
+        properties: {
+          ones: {
+            type: 'array',
+            name: 'ones',
+            items: {
+              $ref: '#/definitions/One'
+            }
+          }
+        },
+        type: 'object'
+      });
+
+      expect(response.result.definitions.One).to.equal({
+        properties: {
+          value: {
+            type: 'string'
+          }
+        },
+        type: 'object'
+      });
+
+      expect(response.result.definitions.ones).to.be.undefined;
+    }
+  );
 });
 
 lab.experiment('joi extension - ', () => {


### PR DESCRIPTION
Hello, not sure you want this but here it is. We are using `hapi-swagger` to generate swagger that is then run through `openapi-generator` to create a typescript client library. The current version of `hapi-swagger` creates intermediate definitions for array properties. Here's an example - for a schema like this: 

` 
Joi.object({
  items: Joi.array().items(
    Joi.object({
        value: Joi.string()
    }).label('SubSchema')
  )
}).label('Schema');
`

`hapi-swagger` would generate three definitions: `Schema` -> `items` -> `SubSchema`. The intermediate `items` definition is not desirable because you get this entity when you use a code generator. I've added a new setting called `definitionsForArraysOfObjects` that disables these intermediate definitions. The default for this new setting is `true` which means the current behavior is unchanged. Setting `definitionsForArraysOfObjects` to `false` generates definitions like this: `Schema` -> `SubSchema`.
     