### PR TITLE
Drop override values when present

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -114,6 +114,15 @@ internals.properties.prototype.parseProperty = function(name, joiObj, parent, pa
   let describe = joiObj.describe();
   const allowDropdown = !property['x-meta'] || !property['x-meta'].disableDropdown;
   if (allowDropdown && Array.isArray(describe.allow) && describe.allow.length) {
+    if (
+      describe.allow[0] &&
+      typeof describe.allow[0] === 'object' &&
+      describe.allow[0].override === true &&
+      Object.keys(describe.allow[0]).length === 1
+    ) {
+      describe.allow.shift();
+    }
+
     // filter out empty values and arrays
     var enums = describe.allow.filter(item => {
       return item !== '' && item !== null;

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -142,6 +142,10 @@ lab.experiment('property - ', () => {
       type: 'string',
       enum: ['a', 'b']
     });
+    expect(propertiesNoAlt.parseProperty('x', Joi.compile(['a', 'b', null]), null, 'body', true, false)).to.equal({
+      type: 'string',
+      enum: ['a', 'b']
+    });
     expect(
       propertiesNoAlt.parseProperty(
         'x',


### PR DESCRIPTION
Joi@17 started adding an override special value on allow/disallow lists (see [here](https://github.com/sideway/joi/blob/83092836583a7f4ce16cbf116b8776737e80d16f/test/base.js#L3490-L3490)), there appears to be no reliable way to detect that value, so I went as far as I could to make sure that's the one and strip it, but there's no guarantee.

Also, the tests don't pass locally based on coverage, but that's not really new.