### PR TITLE
Add security requirements type to root document

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,10 +114,13 @@ declare namespace hapiswagger {
 
   /**
    * Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes)
-   * The name used for each property MUST correspond to a security scheme declared in the {@link RegisterOptions.securityDefinitions}
+   * 
+   * The name used for each property MUST correspond to a security scheme declared in the {@link RegisterOptions.securityDefinitions}.
+   * 
+   * If the security scheme is of `type` "oauth2", then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
    */
   type SecurityRequirementsType = {
-    [securityDefinitionName: string]: [string]
+    [securityDefinitionName: string]: string[]
   }
 
   interface LicenseOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,14 +114,14 @@ declare namespace hapiswagger {
 
   /**
    * Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes)
-   * 
-   * The name used for each property MUST correspond to a security scheme declared in the {@link RegisterOptions.securityDefinitions}.
-   * 
-   * If the security scheme is of `type` "oauth2", then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty.
+   *
+   * The name used for each property MUST correspond to a security scheme declared in the {@link RegisterOptions.securityDefinitions}
+   *
+   * If the security scheme is of `type` "oauth2", then the value is a list of scope names required for the execution. For other security scheme types, the array MUST be empty
    */
   type SecurityRequirementsType = {
-    [securityDefinitionName: string]: string[]
-  }
+    [securityDefinitionName: string]: string[];
+  };
 
   interface LicenseOptions {
     /**
@@ -449,12 +449,12 @@ declare namespace hapiswagger {
     /**
      * A declaration of the security schemes available to be used in the specification. This does not enforce the security schemes on the operations and only serves to provide the relevant details for each scheme
      */
-     securityDefinitions?: {[name: string]: SecuritySchemeType}
+    securityDefinitions?: { [name: string]: SecuritySchemeType };
 
     /**
-      * A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements)
-      */
-     security?: [SecurityRequirementsType]
+     * A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements)
+     */
+    security?: [SecurityRequirementsType];
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,14 @@ declare namespace hapiswagger {
     [key: string]: any;
   }
 
+  /**
+   * Lists the required security schemes to execute this operation. The object can have multiple security schemes declared in it which are all required (that is, there is a logical AND between the schemes)
+   * The name used for each property MUST correspond to a security scheme declared in the {@link RegisterOptions.securityDefinitions}
+   */
+  type SecurityRequirementsType = {
+    [securityDefinitionName: string]: [string]
+  }
+
   interface LicenseOptions {
     /**
      * The name of the license used for the API
@@ -439,6 +447,11 @@ declare namespace hapiswagger {
      * A declaration of the security schemes available to be used in the specification. This does not enforce the security schemes on the operations and only serves to provide the relevant details for each scheme
      */
      securityDefinitions?: {[name: string]: SecuritySchemeType}
+
+    /**
+      * A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements)
+      */
+     security?: [SecurityRequirementsType]
   }
 }
 

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -35,6 +35,7 @@
 -   `grouping`: (string) how to create grouping of endpoints value either `path` or `tags` - default: `path`
 -   `tagsGroupingFilter`: (function) A function used to determine which tags should be used for grouping (when `grouping` is set to `tags`) - default: `(tag) => tag !== 'api'`
 -   `securityDefinitions:`: (object) Containing [Security Definitions Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject). No defaults are provided.
+-   `security`: (array) Containing [Security Requirement Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#securityRequirementObject). No defaults are provided.
 -   `payloadType`: (string) How payload parameters are displayed `json` or `form` - default: `json`
 -   `documentationRouteTags`: (string or array) Add hapi tags to internal `hapi-swagger` routes - default: `[]`
 -   `documentationRoutePlugins`: (object) Add hapi plugins to internal `hapi-swagger` routes - default: `{}`


### PR DESCRIPTION
## Description

This PR adds the following type definitions:
- [Security Requirement Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#security-requirement-object)

This PR also exposes the proper typing for the `security` property for the [root Swagger document](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#schema). This is already enforced through Joi [here](https://github.com/glennjones/hapi-swagger/blob/master/lib/builder.js#L46) which is validating the schema for this root object.

### `security` Property
Root-level description is taken from https://swagger.io/specification/v2/
![image](https://user-images.githubusercontent.com/14851080/126878909-ac440275-2399-48e4-9d36-24d731a848c0.png)

### `securityRequirement` Property
Inner-property description is taken from https://swagger.io/specification/v2/#security-requirement-object
![image](https://user-images.githubusercontent.com/14851080/126878934-862eeab2-1029-4910-a2d5-902c3f99e613.png)
