### PR TITLE
feat: add support for format field in number properties

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -373,13 +373,14 @@ internals.properties.prototype.parseNumber = function (property, joiObj) {
   property.maximum = internals.getArgByName(describe.rules, 'max');
   if (internals.hasPropertyByName(describe.rules, 'integer')) {
     property.type = 'integer';
-    if (Array.isArray(describe.metas)) {
-      const meta = describe.metas.find((meta) => {
-        return typeof meta.format === 'string';
-      });
-      if (meta) {
-        property.format = meta.format;
-      }
+  }
+  
+  if (Array.isArray(describe.metas)) {
+    const meta = describe.metas.find((meta) => {
+      return typeof meta.format === 'string';
+    });
+    if (meta) {
+      property.format = meta.format;
     }
   }
 

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -53,6 +53,10 @@ lab.experiment('property - ', () => {
     expect(propertiesNoAlt.parseProperty('x', Joi.number(), null, 'body', true, false)).to.equal({
       type: 'number'
     });
+    expect(propertiesNoAlt.parseProperty('x', Joi.number().meta({ format: 'float' }), null, 'body', true, false)).to.equal({
+      type: 'number',
+      format: 'float'
+    });
     expect(propertiesNoAlt.parseProperty('x', Joi.number().integer(), null, 'body', true, false)).to.equal({
       type: 'integer'
     });

--- a/usageguide.md
+++ b/usageguide.md
@@ -16,7 +16,7 @@
 -   [File upload](#file-upload)
 -   [Prevent JOI properties from being included in the Swagger schema](#prevent-joi-properties-from-being-included-in-the-swagger-schema)
 -   [Name JOI properties for XML formats](#name-joi-properties-for-xml-formats)
--   [Set format field to JOI integer properties](#set-format-field-to-joi-integer-properties)
+-   [Set format field to JOI number properties](#set-format-field-to-joi-number-properties)
 -   [Headers and .unknown()](#headers-and-unknown)
 -   [Additional Hapi data using x-\*](#additional-hapi-data-using-x-)
 -   [JSON without UI](#json-without-ui)
@@ -515,10 +515,11 @@ Joi.array()
 
 See this link for more info: [OpenAPI 2.0 XML object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#xmlObject)
 
-## Set format field to JOI integer properties
+## Set format field to JOI number properties
 
-You can pass the format property with value `int32` or `int64` on JOI integer properties, as defined in the [guide of OpenAPI 3.0](https://swagger.io/docs/specification/data-models/data-types/#numbers).
+For JOI number properties you can pass the format property. Valid values are `float` or `double` for number properties, and `int32` or `int64` for integer properties, as defined in the [guide of OpenAPI 3.0](https://swagger.io/docs/specification/data-models/data-types/#numbers).
 
+`.number().meta({ format: 'double' })`
 `.number().integer().meta({ format: 'int64' })`
 
 ## Default values and examples


### PR DESCRIPTION
Similarly to PR #742, this pull request allows to set the format field in all number properties as well, not limited to integer properties. 

As stated [here](https://swagger.io/docs/specification/data-models/data-types/), number properties can optionally have the format field with values `float` or `double`.
