### PR TITLE
feat: add minimal support for additionalProperties

### DIFF
--- a/lib/properties.js
+++ b/lib/properties.js
@@ -175,25 +175,8 @@ internals.properties.prototype.parseProperty = function (name, joiObj, parent, p
         };
       }
     } else if (joiObj.$_terms.patterns) {
-      const objectPattern = joiObj.$_terms.patterns[0];
-      let patternName = 'string';
-      if (objectPattern.schema) {
-        patternName =
-          objectPattern.schema.$_terms.examples && objectPattern.schema.$_terms.examples[0]
-            ? objectPattern.schema.$_terms.examples[0]
-            : objectPattern.schema.type;
-      }
-
-      property.properties = {
-        [patternName]: this.parseProperty(
-          patternName,
-          objectPattern.rule,
-          property,
-          parameterType,
-          useDefinitions,
-          isAlt
-        )
-      };
+      property.properties = {};
+      property = this.parsePatterns(property, joiObj, parameterType, useDefinitions, isAlt);
     } else {
       // default empty object
       property.properties = {};
@@ -508,6 +491,40 @@ internals.properties.prototype.parseObject = function (property, joiObj, name, p
       }
     }
   });
+
+  if (joiObj.$_terms.patterns) {
+    property = this.parsePatterns(property, joiObj, parameterType, useDefinitions, isAlt);
+  }
+
+  return property;
+};
+
+/**
+ * parse pattern rule
+ *
+ * @param  {Object} property
+ * @param  {Object} joiObj
+ * @param  {string} parameterType
+ * @param  {Boolean} useDefinitions
+ * @param  {Boolean} isAlt
+ * @return {Object}
+ */
+internals.properties.prototype.parsePatterns = function (property, joiObj, parameterType, useDefinitions, isAlt) {
+  const objectPattern = joiObj.$_terms.patterns.find((pattern) => !!pattern.rule);
+
+  if (objectPattern.rule.type === 'any') {
+    property.additionalProperties = true;
+  } else {
+    property.additionalProperties = this.parseProperty(
+      undefined,
+      objectPattern.rule,
+      property,
+      parameterType,
+      useDefinitions,
+      isAlt
+    );
+  }
+
   return property;
 };
 

--- a/test/unit/property-test.js
+++ b/test/unit/property-test.js
@@ -674,6 +674,155 @@ versions.forEach((version) => {
           items: { type: 'string' }
         });
       });
+
+      lab.test('object pattern tests', () => {
+        clearDown();
+
+        // any key mapped to given value schema
+        expect(
+          propertiesNoAlt.parseProperty(
+            undefined,
+            Joi.object().keys({
+              a: Joi.object().pattern(Joi.string(), Joi.array().items(Joi.string())),
+              b: Joi.array().items(Joi.string())
+            }),
+            null,
+            'body',
+            false,
+            false
+          )
+        ).to.equal({
+          type: 'object',
+          properties: {
+            a: {
+              type: 'object',
+              additionalProperties: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            },
+            b: {
+              type: 'array',
+              items: {
+                type: 'string'
+              }
+            }
+          }
+        });
+
+        expect(
+          propertiesNoAlt.parseProperty(
+            undefined,
+            Joi.object().keys({
+              a: Joi.object().pattern(Joi.string(), Joi.array().items(Joi.string())),
+              b: Joi.array().items(Joi.string()),
+              c: Joi.object().pattern(
+                /./,
+                Joi.object().keys({
+                  d: Joi.string().required(),
+                  e: Joi.boolean().optional()
+                })
+              )
+            }),
+            null,
+            'body',
+            false,
+            false
+          )
+        ).to.equal(
+          {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  }
+                }
+              },
+              b: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              },
+              c: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'object',
+                  properties: {
+                    d: {
+                      type: 'string'
+                    },
+                    e: {
+                      type: 'boolean'
+                    }
+                  },
+                  required: ['d']
+                }
+              }
+            }
+          },
+          { skip: 'optional' }
+        );
+
+        // any key mapped to any value schema
+        expect(
+          propertiesNoAlt.parseProperty(undefined, Joi.object().pattern(/./, Joi.any()), null, 'body', false, false)
+        ).to.equal({
+          type: 'object',
+          additionalProperties: true
+        });
+
+        expect(
+          propertiesNoAlt.parseProperty(
+            undefined,
+            Joi.object().pattern(Joi.string(), Joi.any()),
+            null,
+            'body',
+            false,
+            false
+          )
+        ).to.equal({
+          type: 'object',
+          additionalProperties: true
+        });
+
+        // required keys and optional keys mapped to strings
+        expect(
+          propertiesNoAlt.parseProperty(
+            undefined,
+            Joi.object()
+              .keys({
+                a: Joi.string().required(),
+                b: Joi.string().required()
+              })
+              .pattern(/./, Joi.string()),
+            null,
+            'body',
+            false,
+            false
+          )
+        ).to.equal({
+          type: 'object',
+          properties: {
+            a: {
+              type: 'string'
+            },
+            b: {
+              type: 'string'
+            }
+          },
+          required: ['a', 'b'],
+          additionalProperties: {
+            type: 'string'
+          }
+        });
+      });
     });
 
     lab.test('parse type object', () => {
@@ -754,13 +903,11 @@ versions.forEach((version) => {
         )
       ).to.equal({
         type: 'object',
-        properties: {
-          string: {
-            type: 'object',
-            properties: {
-              y: {
-                type: 'string'
-              }
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            y: {
+              type: 'string'
             }
           }
         }
@@ -782,13 +929,11 @@ versions.forEach((version) => {
         )
       ).to.equal({
         type: 'object',
-        properties: {
-          a: {
-            type: 'object',
-            properties: {
-              y: {
-                type: 'string'
-              }
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            y: {
+              type: 'string'
             }
           }
         }
@@ -810,13 +955,11 @@ versions.forEach((version) => {
         )
       ).to.equal({
         type: 'object',
-        properties: {
-          string: {
-            type: 'object',
-            properties: {
-              y: {
-                type: 'string'
-              }
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            y: {
+              type: 'string'
             }
           }
         }


### PR DESCRIPTION
Resolves #498
Fixes #688 

This adds support for the [additionalProperties ](https://swagger.io/docs/specification/v3_0/data-models/dictionaries/) keyword as OAS 2 & 3 both support this functionality.

This allows users to finally accurately generate schemas for structure data where any key can map to a given value/schema.
This also supports allowing certain keys to be specified and required, while allowing "additional" structure data.

Tests were added, but truthfully it appears the the existing test suite no longer works as expected. Locally for me on master there are 4 failing tests.