### PR TITLE
feat: add support for externalDocs in OpenAPI paths

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -37,7 +37,13 @@ exports =
         responses: Joi.object().required(),
         schemes: Joi.array().items(Joi.string().valid('http', 'https', 'ws', 'wss')),
         deprecated: Joi.boolean(),
-        security: Joi.array().items(Joi.object())
+        security: Joi.array().items(Joi.object()),
+        externalDoc: Joi.array().items(
+          Joi.object({
+            url: Joi.string().uri(),
+            description: Joi.string()
+          })
+        )
       });
     };
 
@@ -139,6 +145,7 @@ internals.createRouteMetaData = function (route, routeOptions) {
     security: Hoek.reach(routeOptions, 'security') || null,
     order: Hoek.reach(routeOptions, 'order') || null,
     deprecated: Hoek.reach(routeOptions, 'deprecated') || null,
+    externalDocs: Hoek.reach(routeOptions, 'externalDocs'),
     id: Hoek.reach(routeOptions, 'id') || null,
     groups: route.group
   };
@@ -400,6 +407,7 @@ internals.paths.prototype.buildOpenApiRoutes = function (routes) {
       summary: route.description,
       operationId: route.id || Utilities.createId(route.method, path),
       description: route.notes,
+      externalDocs: route.externalDocs,
       parameters: []
     };
 

--- a/optionsreference.md
+++ b/optionsreference.md
@@ -86,6 +86,7 @@
 -   `order`: (int) The order in which endpoints are displayed, works with `options.sortEndpoints === ordered`
 -   `x-*` (any): any property or object with a key starting with `x-*` is included in the swagger definition (similar to `x-*` options in the `info` object).
 -   `deprecated`: (boolean) Whether a endpoint has been deprecated - default: false
+-   `externalDocs`: (array) An array of [External Documentation Object](https://swagger.io/docs/specification/v3_0/paths-and-operations/).
 
 ## Route Options
 

--- a/test/Integration/path-openapi-test.js
+++ b/test/Integration/path-openapi-test.js
@@ -56,7 +56,32 @@ lab.experiment('path (OpenAPI)', () => {
     expect(isValid).to.be.true();
   });
 
-  lab.test('route settting of consumes produces', async () => {
+  lab.test('route settings of externalDocs', async () => {
+    const testRoutes = Hoek.clone(routes);
+    testRoutes.options.plugins = {
+      'hapi-swagger': {
+        externalDocs: {
+          description: 'Find more info here',
+          url: 'https://example.com/docs'
+        }
+      }
+    };
+
+    const server = await Helper.createServer({ OAS: 'v3.0' }, testRoutes);
+    const response = await server.inject({ method: 'GET', url: '/openapi.json' });
+    expect(response.statusCode).to.equal(200);
+
+    expect(response.result.paths['/test'].post.externalDocs).to.equal({
+      description: 'Find more info here',
+      url: 'https://example.com/docs'
+    });
+
+    const isValid = await Validate.test(response.result);
+
+    expect(isValid).to.be.true();
+  });
+
+  lab.test('route setting of consumes produces', async () => {
     const testRoutes = Hoek.clone(routes);
     testRoutes.options.plugins = {
       'hapi-swagger': {


### PR DESCRIPTION
Hi team,

This pull request introduces support for the externalDocs property at the path level in the Swagger/OpenAPI documentation generated by the plugin. 

It allows users to specify an array of External Documentation Objects for each path, improving the ability to link to additional external resources directly from the API documentation. 

The documentation (`optionsreference.md`) has been updated to describe the new option and its usage. This enhancement increases the flexibility and completeness of the generated API docs.

See you ;)